### PR TITLE
added missing answer schemas to AnyAnswerSchema

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dmptool/types",
-  "version": "1.2.2",
+  "version": "1.2.3",
   "description": "TypeScript types for DMPTool",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/src/answers/index.ts
+++ b/src/answers/index.ts
@@ -43,6 +43,7 @@ export * from './textAnswers';
 
 // Union of all possible answers
 export const AnyAnswerSchema = z.discriminatedUnion('type', [
+  AffiliationSearchAnswerSchema,
   BooleanAnswerSchema,
   CheckboxesAnswerSchema,
   CurrencyAnswerSchema,
@@ -50,7 +51,9 @@ export const AnyAnswerSchema = z.discriminatedUnion('type', [
   DateRangeAnswerSchema,
   EmailAnswerSchema,
   // FilteredSearchAnswerSchema,
+  MultiselectBoxAnswerSchema,
   NumberAnswerSchema,
+  NumberRangeAnswerSchema,
   RadioButtonsAnswerSchema,
   SelectBoxAnswerSchema,
   TableAnswerSchema,


### PR DESCRIPTION
Realized that some of the answer schemas were missing from `AnyAnswerSchema`. 

This does not require either the frontend or backend to change as they do not appear to be using `AnyAnswerSchema` (otherwise we would have discovered this issue!)