### PR TITLE
Update the maDMP narrative to make ids optional

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # dmptool-types CHANGELOG
 
+## v3.1.7
+- Made `id` properties in `narrative` portion of the DMP Tool extensions optional
+
 ## v3.1.6
 - Updated dev dependencies
 - Removed unneeded override for minimatch

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dmptool/types",
-  "version": "3.1.6",
+  "version": "3.1.7",
   "description": "TypeScript types for DMPTool",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/schemas/dmpExtension.schema.json
+++ b/schemas/dmpExtension.schema.json
@@ -2155,14 +2155,12 @@
                             }
                           },
                           "required": [
-                            "id",
                             "json"
                           ],
                           "additionalProperties": false
                         }
                       },
                       "required": [
-                        "id",
                         "order",
                         "text"
                       ],
@@ -2171,7 +2169,6 @@
                   }
                 },
                 "required": [
-                  "id",
                   "order",
                   "title",
                   "question"
@@ -2181,7 +2178,6 @@
             }
           },
           "required": [
-            "id",
             "title",
             "section"
           ],

--- a/schemas/dmptoolDmp.schema.json
+++ b/schemas/dmptoolDmp.schema.json
@@ -4212,14 +4212,12 @@
                                 }
                               },
                               "required": [
-                                "id",
                                 "json"
                               ],
                               "additionalProperties": false
                             }
                           },
                           "required": [
-                            "id",
                             "order",
                             "text"
                           ],
@@ -4228,7 +4226,6 @@
                       }
                     },
                     "required": [
-                      "id",
                       "order",
                       "title",
                       "question"
@@ -4238,7 +4235,6 @@
                 }
               },
               "required": [
-                "id",
                 "title",
                 "section"
               ],

--- a/src/dmp/__tests__/extensions.spec.ts
+++ b/src/dmp/__tests__/extensions.spec.ts
@@ -82,11 +82,9 @@ describe('extensions', () => {
             description: 'The first section of the narrative',
             order: 1,
             question: [{
-              id: 1234,
               text: 'What is the purpose of this DMP?',
               order: 1,
               answer: {
-                id: 543,
                 json: {
                   type: 'repositorySearch',
                   answer: [{

--- a/src/dmp/extension.ts
+++ b/src/dmp/extension.ts
@@ -105,50 +105,46 @@ const VersionSchema = z.object({
 });
 
 const NarrativeAnswerSchema = z.object({
-  id: z.number(),
+  id: z.number().optional(),
   json: AnyAnswerSchema,
 });
 const DefaultAnswer = NarrativeAnswerSchema.parse({
-  id: 0,
   json: DefaultTextAreaAnswer
 });
 
 const NarrativeQuestionSchema = z.object({
-  id: z.number(),
+  id: z.number().optional(),
   order: z.number(),
   text: z.string(),
   answer: NarrativeAnswerSchema.optional(),
 });
 const DefaultQuestion = NarrativeQuestionSchema.parse({
-  id: 0,
   order: 0,
   text: 'Undefined question text',
   answer: DefaultAnswer
 });
 
 const NarrativeSectionSchema = z.object({
-  id: z.number(),
+  id: z.number().optional(),
   order: z.number(),
   title: z.string(),
   description: z.string().optional(),
   question: z.array(NarrativeQuestionSchema)
 });
 const DefaultSection = NarrativeSectionSchema.parse({
-  id: 0,
   order: 0,
   title: 'Undefined section',
   question: [DefaultQuestion]
 });
 
 const NarrativeTemplateSchema = z.object({
-  id: z.number(),
+  id: z.number().optional(),
   title: z.string(),
   description: z.string().optional(),
   version: z.string().optional(),
   section: z.array(NarrativeSectionSchema)
 });
 const DefaultNarrativeTemplate = NarrativeTemplateSchema.parse({
-  id: 0,
   title: 'Undefined template',
   section: [DefaultSection]
 });


### PR DESCRIPTION
## Description

Work to support [#262](https://github.com/CDLUC3/dmptool-doc/issues/262) and the dmp-bridge project.

- Made all `id` properties within the `narrative` portion of the maDMP JSON optional.

The REST API will attempt to find the template/section/question/answer by other data points if the id is not available.

This will also facilitate future integration with the dmp-bridge project where we do not have a matching template in the database.

**I have not published yet to NPM**

## Type of change

- [x] New feature (non-breaking change which adds functionality)

This should have no impact on the existing use of the maDMP schemas since we are generating the records from data within the DB and will always have the ids available.

## How Has This Been Tested?

Tests are passing. The narrative generator still works and the Apollo server is able to generate maDMP records for Dynamo.

## Checklist:
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I updated the CHANGELOG.md and added documentation if necessary
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
