### PR TITLE
Refactor researchOutputTable schema

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,5 +8,8 @@ dist
 # Ignore the dependency directory
 node_modules
 
+# Ignore npm pack artifacts
+dmptool-types-*.tgz
+
 # Ignore WebStorm IDE file
 .idea

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 # dmptool-types CHANGELOG
 
-## v3.2.0
+## v4.0.0
+**Breaking Change**: Updated `researchOutputTable` questions and answers to include `commonStandardId` property, which is required to map entries from the `dataset` array in the RDA common standard. This change may require updates to any code that uses the `researchOutputTable` questions and answers.
+
 - Added new exports for `ResearchOutputTable` columns and mappings for commonStandardId to Types, Schemas and Defaults
 - Removed `optional` flag from the `commonStandardId` property on `researchOutputTable` questions and answers, since we need this to map entries from the `dataset` array in the RDA common standard 
 - Updated dev dependencies

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # dmptool-types CHANGELOG
 
+## v3.2.0
+- Added new exports for `ResearchOutputTable` columns and mappings for commonStandardId to Types, Schemas and Defaults
+- Removed `optional` flag from the `commonStandardId` property on `researchOutputTable` questions and answers, since we need this to map entries from the `dataset` array in the RDA common standard 
+- Updated dev dependencies
+
 ## v3.1.7
 - Made `id` properties in `narrative` portion of the DMP Tool extensions optional
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@dmptool/types",
-  "version": "3.1.5",
+  "version": "3.1.7",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@dmptool/types",
-      "version": "3.1.5",
+      "version": "3.1.7",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
@@ -16,9 +16,9 @@
       "devDependencies": {
         "@eslint/js": "^10.0.1",
         "@types/jest": "^30.0.0",
-        "@types/node": "^25.9.3",
+        "@types/node": "^26.0.1",
         "cpy": "^13.2.2",
-        "eslint": "^10.5.0",
+        "eslint": "^10.6.0",
         "husky": "^9.1.7",
         "jest": "^30.4.2",
         "jest-expect-message": "^1.1.3",
@@ -27,7 +27,7 @@
         "ts-node": "^10.9.2",
         "ts-node-dev": "^2.0.0",
         "typescript": "^6.0.3",
-        "typescript-eslint": "^8.61.0"
+        "typescript-eslint": "^8.62.1"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -46,45 +46,135 @@
       }
     },
     "node_modules/@babel/compat-data": {
-      "version": "7.29.0",
-      "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.29.0.tgz",
-      "integrity": "sha512-T1NCJqT/j9+cn8fvkt7jtwbLBfLC/1y1c7NtCeXFRgzGTsafi68MRv8yzkYSapBnFA6L3U2VSc02ciDzoAJhJg==",
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-8.0.0.tgz",
+      "integrity": "sha512-DOjnob/cXOUgDOozCDeq/aK2p5y8dUIVdf6tNhEV1HQRd6I8aQ4f4fbtHRVEvb6lP3BGomrKHiS8ICAASSVQSw==",
       "dev": true,
       "license": "MIT",
       "engines": {
-        "node": ">=6.9.0"
+        "node": "^22.18.0 || >=24.11.0"
       }
     },
     "node_modules/@babel/core": {
-      "version": "7.29.0",
-      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.29.0.tgz",
-      "integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/@babel/core/-/core-8.0.1.tgz",
+      "integrity": "sha512-5FgxM4dLQpMJHSiVATk8foW263dVHQHBVpXYiimNECVWG01f4nFyEbQixeT6Mwvg7TayREJ2gpKl3o2RoMdnqw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/code-frame": "^7.29.0",
-        "@babel/generator": "^7.29.0",
-        "@babel/helper-compilation-targets": "^7.28.6",
-        "@babel/helper-module-transforms": "^7.28.6",
-        "@babel/helpers": "^7.28.6",
-        "@babel/parser": "^7.29.0",
-        "@babel/template": "^7.28.6",
-        "@babel/traverse": "^7.29.0",
-        "@babel/types": "^7.29.0",
-        "@jridgewell/remapping": "^2.3.5",
+        "@babel/code-frame": "^8.0.0",
+        "@babel/generator": "^8.0.0",
+        "@babel/helper-compilation-targets": "^8.0.0",
+        "@babel/helpers": "^8.0.0",
+        "@babel/parser": "^8.0.0",
+        "@babel/template": "^8.0.0",
+        "@babel/traverse": "^8.0.0",
+        "@babel/types": "^8.0.0",
+        "@types/gensync": "^1.0.5",
         "convert-source-map": "^2.0.0",
-        "debug": "^4.1.0",
+        "empathic": "^2.0.1",
         "gensync": "^1.0.0-beta.2",
+        "import-meta-resolve": "^4.2.0",
         "json5": "^2.2.3",
-        "semver": "^6.3.1"
+        "obug": "^2.1.1",
+        "semver": "^7.7.3"
       },
       "engines": {
-        "node": ">=6.9.0"
+        "node": "^22.18.0 || >=24.11.0"
       },
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/babel"
       }
+    },
+    "node_modules/@babel/core/node_modules/@babel/code-frame": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-8.0.0.tgz",
+      "integrity": "sha512-dYYg153EyN2Ekbqw2zAsbd6/JR+9N2SEoC7YV2GyyqMM7x9bLDTjBD6XBhSMLH0wtIVyJj03jWNriQhaN+eoCw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-validator-identifier": "^8.0.0",
+        "js-tokens": "^10.0.0"
+      },
+      "engines": {
+        "node": "^22.18.0 || >=24.11.0"
+      }
+    },
+    "node_modules/@babel/core/node_modules/@babel/generator": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-8.0.0.tgz",
+      "integrity": "sha512-NT9NrVwJsbSV6Y2FSstWa71EETOnzrjkL5/wX3D2mYHtKM+qvqB1DvR4D0Setb/gDBsHzRICifwEWMO8CnTF6g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/parser": "^8.0.0",
+        "@babel/types": "^8.0.0",
+        "@jridgewell/gen-mapping": "^0.3.12",
+        "@jridgewell/trace-mapping": "^0.3.28",
+        "@types/jsesc": "^2.5.0",
+        "jsesc": "^3.0.2"
+      },
+      "engines": {
+        "node": "^22.18.0 || >=24.11.0"
+      }
+    },
+    "node_modules/@babel/core/node_modules/@babel/helper-string-parser": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-8.0.0.tgz",
+      "integrity": "sha512-6mJgmFFFIIO82vvoLt9XtRC7/TkzXfts1t/SpRX4IHSzMgqoPYCWesVu1udUPUWioAE/2fcG6WuI8zrkE1gwrg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^22.18.0 || >=24.11.0"
+      }
+    },
+    "node_modules/@babel/core/node_modules/@babel/helper-validator-identifier": {
+      "version": "8.0.2",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-8.0.2.tgz",
+      "integrity": "sha512-9Fr9QeyCAyi1BR1jKZ6uYQ24EIhQUx5ReHfQU7drOE+TPOb+w11/dsqLkMOT2U29OdCT71XajrOT8xDc1C7orA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^22.18.0 || >=24.11.0"
+      }
+    },
+    "node_modules/@babel/core/node_modules/@babel/parser": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-8.0.0.tgz",
+      "integrity": "sha512-aLxAE+imI9bCcyaPrUDjBv3uSkWieifjLe0kuFOZF0zli0L6GCsTmsePnTr55adbIAgYz2zhN1vnFimCBUYcRQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/types": "^8.0.0"
+      },
+      "bin": {
+        "parser": "bin/babel-parser.js"
+      },
+      "engines": {
+        "node": "^22.18.0 || >=24.11.0"
+      }
+    },
+    "node_modules/@babel/core/node_modules/@babel/types": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-8.0.0.tgz",
+      "integrity": "sha512-K8ponJDxBwDHigkeFqaqT5wLGl4bTlwMafR8k7b5CPxr6Ww+UG9ls8Yx6Tcpboxu97eeGVEEyKcHmEyOwN1vSw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-string-parser": "^8.0.0",
+        "@babel/helper-validator-identifier": "^8.0.0"
+      },
+      "engines": {
+        "node": "^22.18.0 || >=24.11.0"
+      }
+    },
+    "node_modules/@babel/core/node_modules/js-tokens": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-10.0.0.tgz",
+      "integrity": "sha512-lM/UBzQmfJRo9ABXbPWemivdCW8V2G8FHaHdypQaIy523snUjog0W71ayWXTjiR+ixeMyVHN2XcpnTd/liPg/Q==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@babel/generator": {
       "version": "7.29.1",
@@ -104,62 +194,30 @@
       }
     },
     "node_modules/@babel/helper-compilation-targets": {
-      "version": "7.28.6",
-      "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.28.6.tgz",
-      "integrity": "sha512-JYtls3hqi15fcx5GaSNL7SCTJ2MNmjrkHXg4FSpOA/grxK8KwyZ5bubHsCq8FXCkua6xhuaaBit+3b7+VZRfcA==",
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-8.0.0.tgz",
+      "integrity": "sha512-JwculLABZvyPvyLBpwU/E/IbH2uM3mnxNtIJpxnIfb24y1PrdVxK5Dqjle4DpgqpGRnwgC7G8IkzPdSXZrO1Ew==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/compat-data": "^7.28.6",
-        "@babel/helper-validator-option": "^7.27.1",
+        "@babel/compat-data": "^8.0.0",
+        "@babel/helper-validator-option": "^8.0.0",
         "browserslist": "^4.24.0",
-        "lru-cache": "^5.1.1",
-        "semver": "^6.3.1"
+        "lru-cache": "^11.0.0",
+        "semver": "^7.7.3"
       },
       "engines": {
-        "node": ">=6.9.0"
+        "node": "^22.18.0 || >=24.11.0"
       }
     },
     "node_modules/@babel/helper-globals": {
-      "version": "7.28.0",
-      "resolved": "https://registry.npmjs.org/@babel/helper-globals/-/helper-globals-7.28.0.tgz",
-      "integrity": "sha512-+W6cISkXFa1jXsDEdYA8HeevQT/FULhxzR99pxphltZcVaugps53THCeiWA8SguxxpSp3gKPiuYfSWopkLQ4hw==",
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/@babel/helper-globals/-/helper-globals-8.0.0.tgz",
+      "integrity": "sha512-lLozHOM6sWWlxNo8CYqHy4MBZeTvHXNgVPBfPOGsjPKUzHC2Az9QwB6gxdQmpwHl6GlQtbGgS+lj5887guDiLw==",
       "dev": true,
       "license": "MIT",
       "engines": {
-        "node": ">=6.9.0"
-      }
-    },
-    "node_modules/@babel/helper-module-imports": {
-      "version": "7.28.6",
-      "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.28.6.tgz",
-      "integrity": "sha512-l5XkZK7r7wa9LucGw9LwZyyCUscb4x37JWTPz7swwFE/0FMQAGpiWUZn8u9DzkSBWEcK25jmvubfpw2dnAMdbw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@babel/traverse": "^7.28.6",
-        "@babel/types": "^7.28.6"
-      },
-      "engines": {
-        "node": ">=6.9.0"
-      }
-    },
-    "node_modules/@babel/helper-module-transforms": {
-      "version": "7.28.6",
-      "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.28.6.tgz",
-      "integrity": "sha512-67oXFAYr2cDLDVGLXTEABjdBJZ6drElUSI7WKp70NrpyISso3plG9SAGEF6y7zbha/wOzUByWWTJvEDVNIUGcA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@babel/helper-module-imports": "^7.28.6",
-        "@babel/helper-validator-identifier": "^7.28.5",
-        "@babel/traverse": "^7.28.6"
-      },
-      "engines": {
-        "node": ">=6.9.0"
-      },
-      "peerDependencies": {
-        "@babel/core": "^7.0.0"
+        "node": "^22.18.0 || >=24.11.0"
       }
     },
     "node_modules/@babel/helper-plugin-utils": {
@@ -193,27 +251,61 @@
       }
     },
     "node_modules/@babel/helper-validator-option": {
-      "version": "7.27.1",
-      "resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.27.1.tgz",
-      "integrity": "sha512-YvjJow9FxbhFFKDSuFnVCe2WxXk1zWc22fFePVNEaWJEu8IrZVlda6N0uHwzZrUM1il7NC9Mlp4MaJYbYd9JSg==",
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-8.0.0.tgz",
+      "integrity": "sha512-U4Dybxh4WESWHt5XhBeExi4DrY0/DNK1aHpQbsrQXCUbFHuMweT0TpLEWKvaraV2Y6fS+ZXunsZ8zIuZIgvF2Q==",
       "dev": true,
       "license": "MIT",
       "engines": {
-        "node": ">=6.9.0"
+        "node": "^22.18.0 || >=24.11.0"
       }
     },
     "node_modules/@babel/helpers": {
-      "version": "7.28.6",
-      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.28.6.tgz",
-      "integrity": "sha512-xOBvwq86HHdB7WUDTfKfT/Vuxh7gElQ+Sfti2Cy6yIWNW05P8iUslOVcZ4/sKbE+/jQaukQAdz/gf3724kYdqw==",
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-8.0.0.tgz",
+      "integrity": "sha512-wfbi91pM3py96oIiJEz7qIpyXDytgr9zQC1HEWwlGNVRAEmItuU/0a41ZUKu1sJGyhhOIpc4t5vk4PYzt8wpsg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/template": "^7.28.6",
-        "@babel/types": "^7.28.6"
+        "@babel/template": "^8.0.0",
+        "@babel/types": "^8.0.0"
       },
       "engines": {
-        "node": ">=6.9.0"
+        "node": "^22.18.0 || >=24.11.0"
+      }
+    },
+    "node_modules/@babel/helpers/node_modules/@babel/helper-string-parser": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-8.0.0.tgz",
+      "integrity": "sha512-6mJgmFFFIIO82vvoLt9XtRC7/TkzXfts1t/SpRX4IHSzMgqoPYCWesVu1udUPUWioAE/2fcG6WuI8zrkE1gwrg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^22.18.0 || >=24.11.0"
+      }
+    },
+    "node_modules/@babel/helpers/node_modules/@babel/helper-validator-identifier": {
+      "version": "8.0.2",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-8.0.2.tgz",
+      "integrity": "sha512-9Fr9QeyCAyi1BR1jKZ6uYQ24EIhQUx5ReHfQU7drOE+TPOb+w11/dsqLkMOT2U29OdCT71XajrOT8xDc1C7orA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^22.18.0 || >=24.11.0"
+      }
+    },
+    "node_modules/@babel/helpers/node_modules/@babel/types": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-8.0.0.tgz",
+      "integrity": "sha512-K8ponJDxBwDHigkeFqaqT5wLGl4bTlwMafR8k7b5CPxr6Ww+UG9ls8Yx6Tcpboxu97eeGVEEyKcHmEyOwN1vSw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-string-parser": "^8.0.0",
+        "@babel/helper-validator-identifier": "^8.0.0"
+      },
+      "engines": {
+        "node": "^22.18.0 || >=24.11.0"
       }
     },
     "node_modules/@babel/parser": {
@@ -481,38 +573,198 @@
       }
     },
     "node_modules/@babel/template": {
-      "version": "7.28.6",
-      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.28.6.tgz",
-      "integrity": "sha512-YA6Ma2KsCdGb+WC6UpBVFJGXL58MDA6oyONbjyF/+5sBgxY/dwkhLogbMT2GXXyU84/IhRw/2D1Os1B/giz+BQ==",
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/@babel/template/-/template-8.0.0.tgz",
+      "integrity": "sha512-eAD0QW/AlbamBbw0FeGiwasbCVPq5ncW0HNVyLP3B9czqLyh4gvw+5JTSNt6le9+ziAU7mqDZsKTHf3jTb4chQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/code-frame": "^7.28.6",
-        "@babel/parser": "^7.28.6",
-        "@babel/types": "^7.28.6"
+        "@babel/code-frame": "^8.0.0",
+        "@babel/parser": "^8.0.0",
+        "@babel/types": "^8.0.0"
       },
       "engines": {
-        "node": ">=6.9.0"
+        "node": "^22.18.0 || >=24.11.0"
       }
     },
-    "node_modules/@babel/traverse": {
-      "version": "7.29.0",
-      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.29.0.tgz",
-      "integrity": "sha512-4HPiQr0X7+waHfyXPZpWPfWL/J7dcN1mx9gL6WdQVMbPnF3+ZhSMs8tCxN7oHddJE9fhNE7+lxdnlyemKfJRuA==",
+    "node_modules/@babel/template/node_modules/@babel/code-frame": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-8.0.0.tgz",
+      "integrity": "sha512-dYYg153EyN2Ekbqw2zAsbd6/JR+9N2SEoC7YV2GyyqMM7x9bLDTjBD6XBhSMLH0wtIVyJj03jWNriQhaN+eoCw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/code-frame": "^7.29.0",
-        "@babel/generator": "^7.29.0",
-        "@babel/helper-globals": "^7.28.0",
-        "@babel/parser": "^7.29.0",
-        "@babel/template": "^7.28.6",
-        "@babel/types": "^7.29.0",
-        "debug": "^4.3.1"
+        "@babel/helper-validator-identifier": "^8.0.0",
+        "js-tokens": "^10.0.0"
       },
       "engines": {
-        "node": ">=6.9.0"
+        "node": "^22.18.0 || >=24.11.0"
       }
+    },
+    "node_modules/@babel/template/node_modules/@babel/helper-string-parser": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-8.0.0.tgz",
+      "integrity": "sha512-6mJgmFFFIIO82vvoLt9XtRC7/TkzXfts1t/SpRX4IHSzMgqoPYCWesVu1udUPUWioAE/2fcG6WuI8zrkE1gwrg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^22.18.0 || >=24.11.0"
+      }
+    },
+    "node_modules/@babel/template/node_modules/@babel/helper-validator-identifier": {
+      "version": "8.0.2",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-8.0.2.tgz",
+      "integrity": "sha512-9Fr9QeyCAyi1BR1jKZ6uYQ24EIhQUx5ReHfQU7drOE+TPOb+w11/dsqLkMOT2U29OdCT71XajrOT8xDc1C7orA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^22.18.0 || >=24.11.0"
+      }
+    },
+    "node_modules/@babel/template/node_modules/@babel/parser": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-8.0.0.tgz",
+      "integrity": "sha512-aLxAE+imI9bCcyaPrUDjBv3uSkWieifjLe0kuFOZF0zli0L6GCsTmsePnTr55adbIAgYz2zhN1vnFimCBUYcRQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/types": "^8.0.0"
+      },
+      "bin": {
+        "parser": "bin/babel-parser.js"
+      },
+      "engines": {
+        "node": "^22.18.0 || >=24.11.0"
+      }
+    },
+    "node_modules/@babel/template/node_modules/@babel/types": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-8.0.0.tgz",
+      "integrity": "sha512-K8ponJDxBwDHigkeFqaqT5wLGl4bTlwMafR8k7b5CPxr6Ww+UG9ls8Yx6Tcpboxu97eeGVEEyKcHmEyOwN1vSw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-string-parser": "^8.0.0",
+        "@babel/helper-validator-identifier": "^8.0.0"
+      },
+      "engines": {
+        "node": "^22.18.0 || >=24.11.0"
+      }
+    },
+    "node_modules/@babel/template/node_modules/js-tokens": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-10.0.0.tgz",
+      "integrity": "sha512-lM/UBzQmfJRo9ABXbPWemivdCW8V2G8FHaHdypQaIy523snUjog0W71ayWXTjiR+ixeMyVHN2XcpnTd/liPg/Q==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@babel/traverse": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-8.0.0.tgz",
+      "integrity": "sha512-bxTj/W2VclGE6CctlfQOpxg8MPDzXArRqkOBePw8EHfebcjF7fETWSS3BriEECo+UiU/Yblq+xUtSImFu7cTbw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/code-frame": "^8.0.0",
+        "@babel/generator": "^8.0.0",
+        "@babel/helper-globals": "^8.0.0",
+        "@babel/parser": "^8.0.0",
+        "@babel/template": "^8.0.0",
+        "@babel/types": "^8.0.0",
+        "obug": "^2.1.1"
+      },
+      "engines": {
+        "node": "^22.18.0 || >=24.11.0"
+      }
+    },
+    "node_modules/@babel/traverse/node_modules/@babel/code-frame": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-8.0.0.tgz",
+      "integrity": "sha512-dYYg153EyN2Ekbqw2zAsbd6/JR+9N2SEoC7YV2GyyqMM7x9bLDTjBD6XBhSMLH0wtIVyJj03jWNriQhaN+eoCw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-validator-identifier": "^8.0.0",
+        "js-tokens": "^10.0.0"
+      },
+      "engines": {
+        "node": "^22.18.0 || >=24.11.0"
+      }
+    },
+    "node_modules/@babel/traverse/node_modules/@babel/generator": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-8.0.0.tgz",
+      "integrity": "sha512-NT9NrVwJsbSV6Y2FSstWa71EETOnzrjkL5/wX3D2mYHtKM+qvqB1DvR4D0Setb/gDBsHzRICifwEWMO8CnTF6g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/parser": "^8.0.0",
+        "@babel/types": "^8.0.0",
+        "@jridgewell/gen-mapping": "^0.3.12",
+        "@jridgewell/trace-mapping": "^0.3.28",
+        "@types/jsesc": "^2.5.0",
+        "jsesc": "^3.0.2"
+      },
+      "engines": {
+        "node": "^22.18.0 || >=24.11.0"
+      }
+    },
+    "node_modules/@babel/traverse/node_modules/@babel/helper-string-parser": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-8.0.0.tgz",
+      "integrity": "sha512-6mJgmFFFIIO82vvoLt9XtRC7/TkzXfts1t/SpRX4IHSzMgqoPYCWesVu1udUPUWioAE/2fcG6WuI8zrkE1gwrg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^22.18.0 || >=24.11.0"
+      }
+    },
+    "node_modules/@babel/traverse/node_modules/@babel/helper-validator-identifier": {
+      "version": "8.0.2",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-8.0.2.tgz",
+      "integrity": "sha512-9Fr9QeyCAyi1BR1jKZ6uYQ24EIhQUx5ReHfQU7drOE+TPOb+w11/dsqLkMOT2U29OdCT71XajrOT8xDc1C7orA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^22.18.0 || >=24.11.0"
+      }
+    },
+    "node_modules/@babel/traverse/node_modules/@babel/parser": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-8.0.0.tgz",
+      "integrity": "sha512-aLxAE+imI9bCcyaPrUDjBv3uSkWieifjLe0kuFOZF0zli0L6GCsTmsePnTr55adbIAgYz2zhN1vnFimCBUYcRQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/types": "^8.0.0"
+      },
+      "bin": {
+        "parser": "bin/babel-parser.js"
+      },
+      "engines": {
+        "node": "^22.18.0 || >=24.11.0"
+      }
+    },
+    "node_modules/@babel/traverse/node_modules/@babel/types": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-8.0.0.tgz",
+      "integrity": "sha512-K8ponJDxBwDHigkeFqaqT5wLGl4bTlwMafR8k7b5CPxr6Ww+UG9ls8Yx6Tcpboxu97eeGVEEyKcHmEyOwN1vSw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-string-parser": "^8.0.0",
+        "@babel/helper-validator-identifier": "^8.0.0"
+      },
+      "engines": {
+        "node": "^22.18.0 || >=24.11.0"
+      }
+    },
+    "node_modules/@babel/traverse/node_modules/js-tokens": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-10.0.0.tgz",
+      "integrity": "sha512-lM/UBzQmfJRo9ABXbPWemivdCW8V2G8FHaHdypQaIy523snUjog0W71ayWXTjiR+ixeMyVHN2XcpnTd/liPg/Q==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@babel/types": {
       "version": "7.29.0",
@@ -1276,17 +1528,6 @@
         "@jridgewell/trace-mapping": "^0.3.24"
       }
     },
-    "node_modules/@jridgewell/remapping": {
-      "version": "2.3.5",
-      "resolved": "https://registry.npmjs.org/@jridgewell/remapping/-/remapping-2.3.5.tgz",
-      "integrity": "sha512-LI9u/+laYG4Ds1TDKSJW2YPrIlcVYOwi2fUC6xB43lueCjgxV4lffOCZCtYFiH6TNOX+tQKXx97T4IKHbhyHEQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@jridgewell/gen-mapping": "^0.3.5",
-        "@jridgewell/trace-mapping": "^0.3.24"
-      }
-    },
     "node_modules/@jridgewell/resolve-uri": {
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
@@ -1528,6 +1769,13 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@types/gensync": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/@types/gensync/-/gensync-1.0.5.tgz",
+      "integrity": "sha512-MbsRCT7mTikHwKZ0X+LVUTLRrZZRLipTuXEO9qOYO+zmjMVk81axyClMROf6uoPD9MRVu46bx8zoR0Ad9q3NAg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@types/istanbul-lib-coverage": {
       "version": "2.0.6",
       "resolved": "https://registry.npmjs.org/@types/istanbul-lib-coverage/-/istanbul-lib-coverage-2.0.6.tgz",
@@ -1566,6 +1814,13 @@
         "pretty-format": "^30.0.0"
       }
     },
+    "node_modules/@types/jsesc": {
+      "version": "2.5.1",
+      "resolved": "https://registry.npmjs.org/@types/jsesc/-/jsesc-2.5.1.tgz",
+      "integrity": "sha512-9VN+6yxLOPLOav+7PwjZbxiID2bVaeq0ED4qSQmdQTdjnXJSaCVKTR58t15oqH1H5t8Ng2ZX1SabJVoN9Q34bw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@types/json-schema": {
       "version": "7.0.15",
       "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.15.tgz",
@@ -1574,13 +1829,13 @@
       "license": "MIT"
     },
     "node_modules/@types/node": {
-      "version": "25.9.3",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-25.9.3.tgz",
-      "integrity": "sha512-603BddQMv3pUcr4U2dhujk83N2tTDVr/34wII2B6bJy6g+8WD6yUb11jszNs0gdi4PesVWl7ABt8nYMVpnLUcg==",
+      "version": "26.0.1",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-26.0.1.tgz",
+      "integrity": "sha512-fc3KiUoBt6kie0N9bIW3E47vZsuaMf0PM2AaUpLCLT0s/LvX1nxAim6Fc049cNxODPpGm6qRAuUOB86SkRuPQw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "undici-types": ">=7.24.0 <7.24.7"
+        "undici-types": "~8.3.0"
       }
     },
     "node_modules/@types/stack-utils": {
@@ -1622,17 +1877,17 @@
       "license": "MIT"
     },
     "node_modules/@typescript-eslint/eslint-plugin": {
-      "version": "8.61.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.61.0.tgz",
-      "integrity": "sha512-bFNvl9ZczlVb+wR2Akszf3gHfKVj/8WanXaGJ3UstTA7brNKg0cNdk6X1Psu5V7MZ2oQtzZKOEzIUehaoxbDGw==",
+      "version": "8.62.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.62.1.tgz",
+      "integrity": "sha512-4EQM77WgVNxj7OkL/5b/D/xZsw00G577+UriYTC7JF5opcF3T2AuoeY7ueLaZgSVjSgCS6yOAJB5bRGLPSJUzA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@eslint-community/regexpp": "^4.12.2",
-        "@typescript-eslint/scope-manager": "8.61.0",
-        "@typescript-eslint/type-utils": "8.61.0",
-        "@typescript-eslint/utils": "8.61.0",
-        "@typescript-eslint/visitor-keys": "8.61.0",
+        "@typescript-eslint/scope-manager": "8.62.1",
+        "@typescript-eslint/type-utils": "8.62.1",
+        "@typescript-eslint/utils": "8.62.1",
+        "@typescript-eslint/visitor-keys": "8.62.1",
         "ignore": "^7.0.5",
         "natural-compare": "^1.4.0",
         "ts-api-utils": "^2.5.0"
@@ -1645,7 +1900,7 @@
         "url": "https://opencollective.com/typescript-eslint"
       },
       "peerDependencies": {
-        "@typescript-eslint/parser": "^8.61.0",
+        "@typescript-eslint/parser": "^8.62.1",
         "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
         "typescript": ">=4.8.4 <6.1.0"
       }
@@ -1661,16 +1916,16 @@
       }
     },
     "node_modules/@typescript-eslint/parser": {
-      "version": "8.61.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.61.0.tgz",
-      "integrity": "sha512-5B7PfA2e1NQGCnDHd/0lW7W3gvp3d59Ryw54FYO8Uswxo9f6ikw3AZV+Xj/TvpImmpsiYyUqAfhC6kJID1jF6w==",
+      "version": "8.62.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.62.1.tgz",
+      "integrity": "sha512-sPhE4iHuJDSvoAiec+Ro8JyXw8f0ql13HFR82P99nCm9GwTEKG0KYLvDe6REk8BCXuit6vJAv/Yxg5ABaNS2rA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/scope-manager": "8.61.0",
-        "@typescript-eslint/types": "8.61.0",
-        "@typescript-eslint/typescript-estree": "8.61.0",
-        "@typescript-eslint/visitor-keys": "8.61.0",
+        "@typescript-eslint/scope-manager": "8.62.1",
+        "@typescript-eslint/types": "8.62.1",
+        "@typescript-eslint/typescript-estree": "8.62.1",
+        "@typescript-eslint/visitor-keys": "8.62.1",
         "debug": "^4.4.3"
       },
       "engines": {
@@ -1686,14 +1941,14 @@
       }
     },
     "node_modules/@typescript-eslint/project-service": {
-      "version": "8.61.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/project-service/-/project-service-8.61.0.tgz",
-      "integrity": "sha512-DV42F7MLJO6Rax7SK1yg43tcnEfGUrurSpSxKuVX+a3RCTzBlH3fuxprrOJXKCJGAaw82xXocikJ0uQaqwXgGA==",
+      "version": "8.62.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/project-service/-/project-service-8.62.1.tgz",
+      "integrity": "sha512-yQ3RgY5RkSBpsNS1Bx/JQEcA24FOSdfGktoyprAr5u18390UQdtVcfnEv4nIrIshNnavlVyZBKxQwT1fIAE6cg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/tsconfig-utils": "^8.61.0",
-        "@typescript-eslint/types": "^8.61.0",
+        "@typescript-eslint/tsconfig-utils": "^8.62.1",
+        "@typescript-eslint/types": "^8.62.1",
         "debug": "^4.4.3"
       },
       "engines": {
@@ -1708,14 +1963,14 @@
       }
     },
     "node_modules/@typescript-eslint/scope-manager": {
-      "version": "8.61.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.61.0.tgz",
-      "integrity": "sha512-IWdXFHFSb6mlC3HPc7QsLDm5zYEbUla6trDEHf32D3/dnuUyXd87plScSNXSbm0/RxMvObpI17sv/EDTGrGZkA==",
+      "version": "8.62.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.62.1.tgz",
+      "integrity": "sha512-r4d249KbQ1SFdpeStvob8Ih6aPPIzfqllPVOtvhve6ZcpuVcYo5/7zUWckKpHE7StASX4kTKZTLf0WQm/wPkcg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/types": "8.61.0",
-        "@typescript-eslint/visitor-keys": "8.61.0"
+        "@typescript-eslint/types": "8.62.1",
+        "@typescript-eslint/visitor-keys": "8.62.1"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -1726,9 +1981,9 @@
       }
     },
     "node_modules/@typescript-eslint/tsconfig-utils": {
-      "version": "8.61.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/tsconfig-utils/-/tsconfig-utils-8.61.0.tgz",
-      "integrity": "sha512-O5Amvdv9ztMpxpf+vmFULGG78IE6Qwdr3bCGvqwG4nwc9H2qXkOYJJnRbRHyMkQTjv1d03olqwwwzHLMqpFePQ==",
+      "version": "8.62.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/tsconfig-utils/-/tsconfig-utils-8.62.1.tgz",
+      "integrity": "sha512-xadytJqX9vJVQ2fdQjkcIVigwaOJNWkpjdLt6cEQ+xPnrI1fkp+/jZE/I97k9KUjqtpd25i0HeyZf3T6dutv2g==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -1743,15 +1998,15 @@
       }
     },
     "node_modules/@typescript-eslint/type-utils": {
-      "version": "8.61.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-8.61.0.tgz",
-      "integrity": "sha512-TuBiQYIkd97yBfInHCTKVYMbX4kvEmpOEuixIuzCU9p8BGT1SfyyO0d0IfDMbPIHcjn/hWnusUX5e8v5Xg+X8A==",
+      "version": "8.62.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-8.62.1.tgz",
+      "integrity": "sha512-aXM5xlqXiTxPibXB93cLAURfT3rlizf7uMXISCXy66Isr/9hISJx3yDsKl0L7lKa51b8JpFuNKby0/O0pEm9jg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/types": "8.61.0",
-        "@typescript-eslint/typescript-estree": "8.61.0",
-        "@typescript-eslint/utils": "8.61.0",
+        "@typescript-eslint/types": "8.62.1",
+        "@typescript-eslint/typescript-estree": "8.62.1",
+        "@typescript-eslint/utils": "8.62.1",
         "debug": "^4.4.3",
         "ts-api-utils": "^2.5.0"
       },
@@ -1768,9 +2023,9 @@
       }
     },
     "node_modules/@typescript-eslint/types": {
-      "version": "8.61.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.61.0.tgz",
-      "integrity": "sha512-9QTQpZ5Iin4CdIodfbDQFSeiSJKidgYJYug1P9CC2xWgUTvlmixViqDZNciMjwLBZyJnG4tGmPl97rVAFb1AJg==",
+      "version": "8.62.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.62.1.tgz",
+      "integrity": "sha512-ooCzJFaf+Hg+uG6fA3NRFGuFjlfNlDhBthbv4ZPU/0elCAFUfnyXUvf/WOpHz/jYwSmvU2GkR2LtyUfy1AxZ1Q==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -1782,16 +2037,16 @@
       }
     },
     "node_modules/@typescript-eslint/typescript-estree": {
-      "version": "8.61.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.61.0.tgz",
-      "integrity": "sha512-42zatd5qSvvcV1JdDBCLxYRznvP4eIHpPoZXdkPFnAmanA4FuZ5dibSnCBggY8hQnqajPpoGjXFdZ7fIJKQnlA==",
+      "version": "8.62.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.62.1.tgz",
+      "integrity": "sha512-xMcW9oP9u7fAMXYs9A65CVmtLQe2r//oXINHfi8HV+oiqhih17sbLdhXr4540YWlgpDKQdY854OL5ZrdCiQsAA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/project-service": "8.61.0",
-        "@typescript-eslint/tsconfig-utils": "8.61.0",
-        "@typescript-eslint/types": "8.61.0",
-        "@typescript-eslint/visitor-keys": "8.61.0",
+        "@typescript-eslint/project-service": "8.62.1",
+        "@typescript-eslint/tsconfig-utils": "8.62.1",
+        "@typescript-eslint/types": "8.62.1",
+        "@typescript-eslint/visitor-keys": "8.62.1",
         "debug": "^4.4.3",
         "minimatch": "^10.2.2",
         "semver": "^7.7.3",
@@ -1809,30 +2064,17 @@
         "typescript": ">=4.8.4 <6.1.0"
       }
     },
-    "node_modules/@typescript-eslint/typescript-estree/node_modules/semver": {
-      "version": "7.8.4",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.4.tgz",
-      "integrity": "sha512-rUCObTnP32Q08R2uuIrt7r9PlEonuTmtuXYcW6s5kjdlj3xbnwe+21yXptAUYcMAABLkYYTtnmzb3w3EDZfueA==",
-      "dev": true,
-      "license": "ISC",
-      "bin": {
-        "semver": "bin/semver.js"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
     "node_modules/@typescript-eslint/utils": {
-      "version": "8.61.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.61.0.tgz",
-      "integrity": "sha512-3bzFt7ImFMW/jVYwJamDoe/dMOdFLSC6pom6rRjdh4SZJEYupyMzem8e7vKZLclLfpHjlwSAXOUxtKxGXUiLqA==",
+      "version": "8.62.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.62.1.tgz",
+      "integrity": "sha512-sHtbPfuKNZCG+ih8SyjjucqRntSVmp8XgL5u6o9mAhiSn8ds5o/M/XdM0abweme2Tln3szOstOrZ9OXitvPh0g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.9.1",
-        "@typescript-eslint/scope-manager": "8.61.0",
-        "@typescript-eslint/types": "8.61.0",
-        "@typescript-eslint/typescript-estree": "8.61.0"
+        "@typescript-eslint/scope-manager": "8.62.1",
+        "@typescript-eslint/types": "8.62.1",
+        "@typescript-eslint/typescript-estree": "8.62.1"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -1847,13 +2089,13 @@
       }
     },
     "node_modules/@typescript-eslint/visitor-keys": {
-      "version": "8.61.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.61.0.tgz",
-      "integrity": "sha512-QVLZu3ZPQEE+HICQyAMZ2yLQhxf0meY/wx6Hx14YcTNj13JB3qHlX3lJ02L3fLGHgERRH71kvYDwiXIguT3AjQ==",
+      "version": "8.62.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.62.1.tgz",
+      "integrity": "sha512-4g3BLxfdTMy8iZG0MaBkadnlRrCJ74cQiFbyEVMrkwIoqdyaXXQM22cotDvrl4x28wgIZ9rEJRoM+mmhSJpJ1g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/types": "8.61.0",
+        "@typescript-eslint/types": "8.62.1",
         "eslint-visitor-keys": "^5.0.0"
       },
       "engines": {
@@ -2260,14 +2502,11 @@
       "license": "MIT"
     },
     "node_modules/argparse": {
-      "version": "1.0.10",
-      "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
-      "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
+      "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
       "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "sprintf-js": "~1.0.2"
-      }
+      "license": "Python-2.0"
     },
     "node_modules/babel-jest": {
       "version": "30.4.1",
@@ -2389,9 +2628,9 @@
       }
     },
     "node_modules/baseline-browser-mapping": {
-      "version": "2.10.0",
-      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.10.0.tgz",
-      "integrity": "sha512-lIyg0szRfYbiy67j9KN8IyeD7q7hcmqnJ1ddWmNt19ItGpNN64mnllmxUNFIOdOm6by97jlL6wfpTTJrmnjWAA==",
+      "version": "2.10.40",
+      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.10.40.tgz",
+      "integrity": "sha512-BSSLZ9/Cjjv7Gtj5B68ZzXcXUg8iOf3fme+FCuh8rC/Go+Kmh8cox7M3A8dolou16s64QjLPOSdngh7GxXvkSw==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {
@@ -2441,9 +2680,9 @@
       }
     },
     "node_modules/browserslist": {
-      "version": "4.28.1",
-      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.28.1.tgz",
-      "integrity": "sha512-ZC5Bd0LgJXgwGqUknZY/vkUQ04r8NXnJZ3yYi4vDmSiZmC/pdSN0NbNRPxZpbtO4uAfDUAFffO8IZoM3Gj8IkA==",
+      "version": "4.28.4",
+      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.28.4.tgz",
+      "integrity": "sha512-MTc8i/x9jBQd1iMw2CFGS+rwMa07eYjLR0CCTLDACl9xhxy+nIs3KeML/biicXtk9JrZ6dnnTatmc7ErPXIxqw==",
       "dev": true,
       "funding": [
         {
@@ -2461,11 +2700,11 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "baseline-browser-mapping": "^2.9.0",
-        "caniuse-lite": "^1.0.30001759",
-        "electron-to-chromium": "^1.5.263",
-        "node-releases": "^2.0.27",
-        "update-browserslist-db": "^1.2.0"
+        "baseline-browser-mapping": "^2.10.38",
+        "caniuse-lite": "^1.0.30001799",
+        "electron-to-chromium": "^1.5.376",
+        "node-releases": "^2.0.48",
+        "update-browserslist-db": "^1.2.3"
       },
       "bin": {
         "browserslist": "cli.js"
@@ -2525,9 +2764,9 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001774",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001774.tgz",
-      "integrity": "sha512-DDdwPGz99nmIEv216hKSgLD+D4ikHQHjBC/seF98N9CPqRX4M5mSxT9eTV6oyisnJcuzxtZy4n17yKKQYmYQOA==",
+      "version": "1.0.30001800",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001800.tgz",
+      "integrity": "sha512-MMHtuAz9Ys840zAY5F4k6fV5GaivZ9sPk+nz0mY+GYVzRBnYkN0mpqkSR92oWRQ19yQWo4HvBV/FnC16AJX8MA==",
       "dev": true,
       "funding": [
         {
@@ -2911,9 +3150,9 @@
       "license": "MIT"
     },
     "node_modules/electron-to-chromium": {
-      "version": "1.5.302",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.302.tgz",
-      "integrity": "sha512-sM6HAN2LyK82IyPBpznDRqlTQAtuSaO+ShzFiWTvoMJLHyZ+Y39r8VMfHzwbU8MVBzQ4Wdn85+wlZl2TLGIlwg==",
+      "version": "1.5.382",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.382.tgz",
+      "integrity": "sha512-8ETaWbV6SZOrno+G93Ffd9ENsMtetqdnqj4nlfxFW90Sm5GgnuV28Kf62hqQVD6VUgzm7qFQKsTsAPmeUiU3Ug==",
       "dev": true,
       "license": "ISC"
     },
@@ -2936,6 +3175,16 @@
       "integrity": "sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/empathic": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/empathic/-/empathic-2.0.1.tgz",
+      "integrity": "sha512-YGRs8knHhKHVShLkFET/rWAU8kmHbOV5LwN938RHI0pljAJ1Gf6SzXsSmRaEzcXTtOOmVqJ5+WtQPL5uigY50Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14"
+      }
     },
     "node_modules/error-ex": {
       "version": "1.3.4",
@@ -2971,9 +3220,9 @@
       }
     },
     "node_modules/eslint": {
-      "version": "10.5.0",
-      "resolved": "https://registry.npmjs.org/eslint/-/eslint-10.5.0.tgz",
-      "integrity": "sha512-1y+7C+vi12bUK1IpZeaV3gsH9fHLBmPvYmPx42pvT/E9yG0IC8g3PUZZgp0+JLJl7ZDK0flc2gc+Aw9dpCvIsQ==",
+      "version": "10.6.0",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-10.6.0.tgz",
+      "integrity": "sha512-6lVbcqSodALYo+4ELD0heG6lFiFxnLMuLkiMi2qV8LMp54N8tE8FT1GMH+ev4Ti00nFjNze2+Su6DsV5OQW3Dg==",
       "dev": true,
       "license": "MIT",
       "workspaces": [
@@ -3077,20 +3326,6 @@
       },
       "funding": {
         "url": "https://opencollective.com/eslint"
-      }
-    },
-    "node_modules/esprima": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
-      "integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==",
-      "dev": true,
-      "license": "BSD-2-Clause",
-      "bin": {
-        "esparse": "bin/esparse.js",
-        "esvalidate": "bin/esvalidate.js"
-      },
-      "engines": {
-        "node": ">=4"
       }
     },
     "node_modules/esquery": {
@@ -3639,6 +3874,17 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/import-meta-resolve": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/import-meta-resolve/-/import-meta-resolve-4.2.0.tgz",
+      "integrity": "sha512-Iqv2fzaTQN28s/FwZAoFq0ZSs/7hMAHJVX+w8PZl3cY19Pxk6jFFalxQoIfW2826i/fDLXv8IiEZRIT0lDuWcg==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
     "node_modules/imurmurhash": {
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
@@ -3812,19 +4058,6 @@
         "@istanbuljs/schema": "^0.1.3",
         "istanbul-lib-coverage": "^3.2.0",
         "semver": "^7.5.4"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/istanbul-lib-instrument/node_modules/semver": {
-      "version": "7.7.4",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
-      "integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
-      "dev": true,
-      "license": "ISC",
-      "bin": {
-        "semver": "bin/semver.js"
       },
       "engines": {
         "node": ">=10"
@@ -4451,19 +4684,6 @@
         "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
       }
     },
-    "node_modules/jest-snapshot/node_modules/semver": {
-      "version": "7.8.0",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.0.tgz",
-      "integrity": "sha512-AcM7dV/5ul4EekoQ29Agm5vri8JNqRyj39o0qpX6vDF2GZrtutZl5RwgD1XnZjiTAfncsJhMI48QQH3sN87YNA==",
-      "dev": true,
-      "license": "ISC",
-      "bin": {
-        "semver": "bin/semver.js"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
     "node_modules/jest-util": {
       "version": "30.4.1",
       "resolved": "https://registry.npmjs.org/jest-util/-/jest-util-30.4.1.tgz",
@@ -4587,17 +4807,26 @@
       "license": "MIT"
     },
     "node_modules/js-yaml": {
-      "version": "3.14.2",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.2.tgz",
-      "integrity": "sha512-PMSmkqxr106Xa156c2M265Z+FTrPl+oxd/rgOQy2tijQeK5TxQ43psO1ZCwhVOSdnn+RzkzlRz/eY4BgJBYVpg==",
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-5.2.0.tgz",
+      "integrity": "sha512-YeLUMlvR4Ou1B119LIaM0r65JvbOBooJDc9yEu0dClb/uSC5P4FrLU8OCCz/HXWvtPoIrR0dRzABTjo1sTN9Bw==",
       "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/puzrin"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/nodeca"
+        }
+      ],
       "license": "MIT",
       "dependencies": {
-        "argparse": "^1.0.7",
-        "esprima": "^4.0.0"
+        "argparse": "^2.0.1"
       },
       "bin": {
-        "js-yaml": "bin/js-yaml.js"
+        "js-yaml": "bin/js-yaml.mjs"
       }
     },
     "node_modules/jsesc": {
@@ -4755,13 +4984,13 @@
       "license": "MIT"
     },
     "node_modules/lru-cache": {
-      "version": "5.1.1",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
-      "integrity": "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==",
+      "version": "11.5.1",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.5.1.tgz",
+      "integrity": "sha512-RPimw/7aMdv2oqRrxKwvZXcPfwBrn/JZ2xYcY9Hus/6LaS3VOAKVWKWgNLCFSiOm1ESXinjsDlidVU7JlnCN2A==",
       "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "yallist": "^3.0.2"
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": "20 || >=22"
       }
     },
     "node_modules/make-dir": {
@@ -4778,19 +5007,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/make-dir/node_modules/semver": {
-      "version": "7.8.0",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.0.tgz",
-      "integrity": "sha512-AcM7dV/5ul4EekoQ29Agm5vri8JNqRyj39o0qpX6vDF2GZrtutZl5RwgD1XnZjiTAfncsJhMI48QQH3sN87YNA==",
-      "dev": true,
-      "license": "ISC",
-      "bin": {
-        "semver": "bin/semver.js"
-      },
-      "engines": {
-        "node": ">=10"
       }
     },
     "node_modules/make-error": {
@@ -4945,11 +5161,14 @@
       "license": "MIT"
     },
     "node_modules/node-releases": {
-      "version": "2.0.27",
-      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.27.tgz",
-      "integrity": "sha512-nmh3lCkYZ3grZvqcCH+fjmQ7X+H0OeZgP40OierEaAptX4XofMh5kwNbWh7lBduUzCcV/8kZ+NDLCwm2iorIlA==",
+      "version": "2.0.50",
+      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.50.tgz",
+      "integrity": "sha512-J6l92tKHX6w8Jy5nO1Vuc01NoIiRGi/d6qBKVxh+IQ8Cr3b6HbVNfKiF8ZpFKufTwpwxMmce2W3iQZ861ZRyTg==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
     },
     "node_modules/normalize-path": {
       "version": "3.0.0",
@@ -4972,6 +5191,20 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/obug": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/obug/-/obug-2.1.3.tgz",
+      "integrity": "sha512-9miFgM2OFba7hB+pRgvtV84pYTBaoTHohvmIgiRt6dRIzbwEOIaNaP+dIlGs2fNFoB0SeISs0Jz5WFVRid6Xyg==",
+      "dev": true,
+      "funding": [
+        "https://github.com/sponsors/sxzz",
+        "https://opencollective.com/debug"
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.20.0"
       }
     },
     "node_modules/once": {
@@ -5577,13 +5810,16 @@
       }
     },
     "node_modules/semver": {
-      "version": "6.3.1",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
-      "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
+      "version": "7.8.5",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.5.tgz",
+      "integrity": "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==",
       "dev": true,
       "license": "ISC",
       "bin": {
         "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
       }
     },
     "node_modules/shebang-command": {
@@ -5655,13 +5891,6 @@
         "buffer-from": "^1.0.0",
         "source-map": "^0.6.0"
       }
-    },
-    "node_modules/sprintf-js": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
-      "integrity": "sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g==",
-      "dev": true,
-      "license": "BSD-3-Clause"
     },
     "node_modules/stack-utils": {
       "version": "2.0.6",
@@ -6120,19 +6349,6 @@
         }
       }
     },
-    "node_modules/ts-jest/node_modules/semver": {
-      "version": "7.8.4",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.4.tgz",
-      "integrity": "sha512-rUCObTnP32Q08R2uuIrt7r9PlEonuTmtuXYcW6s5kjdlj3xbnwe+21yXptAUYcMAABLkYYTtnmzb3w3EDZfueA==",
-      "dev": true,
-      "license": "ISC",
-      "bin": {
-        "semver": "bin/semver.js"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
     "node_modules/ts-jest/node_modules/type-fest": {
       "version": "4.41.0",
       "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-4.41.0.tgz",
@@ -6317,16 +6533,16 @@
       }
     },
     "node_modules/typescript-eslint": {
-      "version": "8.61.0",
-      "resolved": "https://registry.npmjs.org/typescript-eslint/-/typescript-eslint-8.61.0.tgz",
-      "integrity": "sha512-8y31Rd0eGTrDKqhy6vT0HtzhN+YLjQizwX3aA3hPXP/ynSfnrBXcQY5IzsP9/DM7+klX4IUncZZjkchP0z+rUw==",
+      "version": "8.62.1",
+      "resolved": "https://registry.npmjs.org/typescript-eslint/-/typescript-eslint-8.62.1.tgz",
+      "integrity": "sha512-vymnnM5g0AKQDSAyfP12nMIBvgwgA42syg74kkuZ4x1VuTzwQKwc5h9rGxeShCjny5o+zWAb6OEoz7XLgrIkIw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/eslint-plugin": "8.61.0",
-        "@typescript-eslint/parser": "8.61.0",
-        "@typescript-eslint/typescript-estree": "8.61.0",
-        "@typescript-eslint/utils": "8.61.0"
+        "@typescript-eslint/eslint-plugin": "8.62.1",
+        "@typescript-eslint/parser": "8.62.1",
+        "@typescript-eslint/typescript-estree": "8.62.1",
+        "@typescript-eslint/utils": "8.62.1"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -6355,9 +6571,9 @@
       }
     },
     "node_modules/undici-types": {
-      "version": "7.24.6",
-      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.24.6.tgz",
-      "integrity": "sha512-WRNW+sJgj5OBN4/0JpHFqtqzhpbnV0GuB+OozA9gCL7a993SmU+1JBZCzLNxYsbMfIeDL+lTsphD5jN5N+n0zg==",
+      "version": "8.3.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-8.3.0.tgz",
+      "integrity": "sha512-j375ScV60dom+YkPFIfTLcOiPxkN/buHz5GobjLhixFuANaNs3C9l4GmrWqejgXWJ7BbJcFYpTEUkS1Ge8bpZQ==",
       "dev": true,
       "license": "MIT"
     },
@@ -6650,13 +6866,6 @@
       "engines": {
         "node": ">=10"
       }
-    },
-    "node_modules/yallist": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz",
-      "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==",
-      "dev": true,
-      "license": "ISC"
     },
     "node_modules/yargs": {
       "version": "17.7.2",

--- a/package.json
+++ b/package.json
@@ -36,6 +36,10 @@
     "trivy-high": "./scripts/trivy-high.sh",
     "trivy-med": "./scripts/trivy-med.sh"
   },
+  "overrides": {
+    "@babel/core": "8.0.1",
+    "js-yaml": "5.2.0"
+  },
   "dependencies": {
     "json-schema-to-ts": "^3.1.1",
     "zod": "^4.4.3"
@@ -43,9 +47,9 @@
   "devDependencies": {
     "@eslint/js": "^10.0.1",
     "@types/jest": "^30.0.0",
-    "@types/node": "^25.9.3",
+    "@types/node": "^26.0.1",
     "cpy": "^13.2.2",
-    "eslint": "^10.5.0",
+    "eslint": "^10.6.0",
     "husky": "^9.1.7",
     "jest": "^30.4.2",
     "jest-expect-message": "^1.1.3",
@@ -54,6 +58,6 @@
     "ts-node": "^10.9.2",
     "ts-node-dev": "^2.0.0",
     "typescript": "^6.0.3",
-    "typescript-eslint": "^8.61.0"
+    "typescript-eslint": "^8.62.1"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dmptool/types",
-  "version": "3.1.7",
+  "version": "4.0.0",
   "description": "TypeScript types for DMPTool",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/schemas/anyAnswer.schema.json
+++ b/schemas/anyAnswer.schema.json
@@ -644,6 +644,126 @@
                       "properties": {
                         "type": {
                           "type": "string",
+                          "const": "text"
+                        },
+                        "meta": {
+                          "type": "object",
+                          "properties": {
+                            "schemaVersion": {
+                              "default": "1.0",
+                              "type": "string"
+                            }
+                          },
+                          "required": [
+                            "schemaVersion"
+                          ],
+                          "additionalProperties": false
+                        },
+                        "comment": {
+                          "type": "string"
+                        },
+                        "answer": {
+                          "default": "",
+                          "type": "string"
+                        },
+                        "commonStandardId": {
+                          "type": "string",
+                          "const": "title"
+                        }
+                      },
+                      "required": [
+                        "type",
+                        "meta",
+                        "answer",
+                        "commonStandardId"
+                      ],
+                      "additionalProperties": false
+                    },
+                    {
+                      "type": "object",
+                      "properties": {
+                        "type": {
+                          "type": "string",
+                          "const": "textArea"
+                        },
+                        "meta": {
+                          "type": "object",
+                          "properties": {
+                            "schemaVersion": {
+                              "default": "1.0",
+                              "type": "string"
+                            }
+                          },
+                          "required": [
+                            "schemaVersion"
+                          ],
+                          "additionalProperties": false
+                        },
+                        "comment": {
+                          "type": "string"
+                        },
+                        "answer": {
+                          "default": "",
+                          "type": "string"
+                        },
+                        "commonStandardId": {
+                          "type": "string",
+                          "const": "description"
+                        }
+                      },
+                      "required": [
+                        "type",
+                        "meta",
+                        "answer",
+                        "commonStandardId"
+                      ],
+                      "additionalProperties": false
+                    },
+                    {
+                      "type": "object",
+                      "properties": {
+                        "type": {
+                          "type": "string",
+                          "const": "selectBox"
+                        },
+                        "meta": {
+                          "type": "object",
+                          "properties": {
+                            "schemaVersion": {
+                              "default": "1.0",
+                              "type": "string"
+                            }
+                          },
+                          "required": [
+                            "schemaVersion"
+                          ],
+                          "additionalProperties": false
+                        },
+                        "comment": {
+                          "type": "string"
+                        },
+                        "answer": {
+                          "default": "",
+                          "type": "string"
+                        },
+                        "commonStandardId": {
+                          "type": "string",
+                          "const": "type"
+                        }
+                      },
+                      "required": [
+                        "type",
+                        "meta",
+                        "answer",
+                        "commonStandardId"
+                      ],
+                      "additionalProperties": false
+                    },
+                    {
+                      "type": "object",
+                      "properties": {
+                        "type": {
+                          "type": "string",
                           "const": "checkBoxes"
                         },
                         "meta": {
@@ -672,13 +792,55 @@
                           }
                         },
                         "commonStandardId": {
-                          "type": "string"
+                          "type": "string",
+                          "const": "data_flags"
                         }
                       },
                       "required": [
                         "type",
                         "meta",
-                        "answer"
+                        "answer",
+                        "commonStandardId"
+                      ],
+                      "additionalProperties": false
+                    },
+                    {
+                      "type": "object",
+                      "properties": {
+                        "type": {
+                          "type": "string",
+                          "const": "radioButtons"
+                        },
+                        "meta": {
+                          "type": "object",
+                          "properties": {
+                            "schemaVersion": {
+                              "default": "1.0",
+                              "type": "string"
+                            }
+                          },
+                          "required": [
+                            "schemaVersion"
+                          ],
+                          "additionalProperties": false
+                        },
+                        "comment": {
+                          "type": "string"
+                        },
+                        "answer": {
+                          "default": "",
+                          "type": "string"
+                        },
+                        "commonStandardId": {
+                          "type": "string",
+                          "const": "data_access"
+                        }
+                      },
+                      "required": [
+                        "type",
+                        "meta",
+                        "answer",
+                        "commonStandardId"
                       ],
                       "additionalProperties": false
                     },
@@ -710,125 +872,15 @@
                           "type": "string"
                         },
                         "commonStandardId": {
-                          "type": "string"
-                        }
-                      },
-                      "required": [
-                        "type",
-                        "meta",
-                        "answer"
-                      ],
-                      "additionalProperties": false
-                    },
-                    {
-                      "type": "object",
-                      "properties": {
-                        "type": {
                           "type": "string",
-                          "const": "licenseSearch"
-                        },
-                        "meta": {
-                          "type": "object",
-                          "properties": {
-                            "schemaVersion": {
-                              "default": "1.0",
-                              "type": "string"
-                            }
-                          },
-                          "required": [
-                            "schemaVersion"
-                          ],
-                          "additionalProperties": false
-                        },
-                        "comment": {
-                          "type": "string"
-                        },
-                        "answer": {
-                          "default": [],
-                          "type": "array",
-                          "items": {
-                            "type": "object",
-                            "properties": {
-                              "licenseId": {
-                                "default": "",
-                                "type": "string"
-                              },
-                              "licenseName": {
-                                "default": "",
-                                "type": "string"
-                              }
-                            },
-                            "required": [
-                              "licenseId",
-                              "licenseName"
-                            ],
-                            "additionalProperties": false
-                          }
-                        },
-                        "commonStandardId": {
-                          "type": "string"
+                          "const": "issued"
                         }
                       },
                       "required": [
                         "type",
                         "meta",
-                        "answer"
-                      ],
-                      "additionalProperties": false
-                    },
-                    {
-                      "type": "object",
-                      "properties": {
-                        "type": {
-                          "type": "string",
-                          "const": "metadataStandardSearch"
-                        },
-                        "meta": {
-                          "type": "object",
-                          "properties": {
-                            "schemaVersion": {
-                              "default": "1.0",
-                              "type": "string"
-                            }
-                          },
-                          "required": [
-                            "schemaVersion"
-                          ],
-                          "additionalProperties": false
-                        },
-                        "comment": {
-                          "type": "string"
-                        },
-                        "answer": {
-                          "default": [],
-                          "type": "array",
-                          "items": {
-                            "type": "object",
-                            "properties": {
-                              "metadataStandardId": {
-                                "default": "",
-                                "type": "string"
-                              },
-                              "metadataStandardName": {
-                                "default": "",
-                                "type": "string"
-                              }
-                            },
-                            "required": [
-                              "metadataStandardId",
-                              "metadataStandardName"
-                            ],
-                            "additionalProperties": false
-                          }
-                        },
-                        "commonStandardId": {
-                          "type": "string"
-                        }
-                      },
-                      "required": [
-                        "type",
-                        "meta",
-                        "answer"
+                        "answer",
+                        "commonStandardId"
                       ],
                       "additionalProperties": false
                     },
@@ -874,51 +926,15 @@
                           "additionalProperties": false
                         },
                         "commonStandardId": {
-                          "type": "string"
-                        }
-                      },
-                      "required": [
-                        "type",
-                        "meta",
-                        "answer"
-                      ],
-                      "additionalProperties": false
-                    },
-                    {
-                      "type": "object",
-                      "properties": {
-                        "type": {
                           "type": "string",
-                          "const": "radioButtons"
-                        },
-                        "meta": {
-                          "type": "object",
-                          "properties": {
-                            "schemaVersion": {
-                              "default": "1.0",
-                              "type": "string"
-                            }
-                          },
-                          "required": [
-                            "schemaVersion"
-                          ],
-                          "additionalProperties": false
-                        },
-                        "comment": {
-                          "type": "string"
-                        },
-                        "answer": {
-                          "default": "",
-                          "type": "string"
-                        },
-                        "commonStandardId": {
-                          "type": "string"
+                          "const": "byte_size"
                         }
                       },
                       "required": [
                         "type",
                         "meta",
-                        "answer"
+                        "answer",
+                        "commonStandardId"
                       ],
                       "additionalProperties": false
                     },
@@ -968,13 +984,15 @@
                           }
                         },
                         "commonStandardId": {
-                          "type": "string"
+                          "type": "string",
+                          "const": "host"
                         }
                       },
                       "required": [
                         "type",
                         "meta",
-                        "answer"
+                        "answer",
+                        "commonStandardId"
                       ],
                       "additionalProperties": false
                     },
@@ -983,7 +1001,7 @@
                       "properties": {
                         "type": {
                           "type": "string",
-                          "const": "selectBox"
+                          "const": "metadataStandardSearch"
                         },
                         "meta": {
                           "type": "object",
@@ -1002,17 +1020,95 @@
                           "type": "string"
                         },
                         "answer": {
-                          "default": "",
-                          "type": "string"
+                          "default": [],
+                          "type": "array",
+                          "items": {
+                            "type": "object",
+                            "properties": {
+                              "metadataStandardId": {
+                                "default": "",
+                                "type": "string"
+                              },
+                              "metadataStandardName": {
+                                "default": "",
+                                "type": "string"
+                              }
+                            },
+                            "required": [
+                              "metadataStandardId",
+                              "metadataStandardName"
+                            ],
+                            "additionalProperties": false
+                          }
                         },
                         "commonStandardId": {
-                          "type": "string"
+                          "type": "string",
+                          "const": "metadata"
                         }
                       },
                       "required": [
                         "type",
                         "meta",
-                        "answer"
+                        "answer",
+                        "commonStandardId"
+                      ],
+                      "additionalProperties": false
+                    },
+                    {
+                      "type": "object",
+                      "properties": {
+                        "type": {
+                          "type": "string",
+                          "const": "licenseSearch"
+                        },
+                        "meta": {
+                          "type": "object",
+                          "properties": {
+                            "schemaVersion": {
+                              "default": "1.0",
+                              "type": "string"
+                            }
+                          },
+                          "required": [
+                            "schemaVersion"
+                          ],
+                          "additionalProperties": false
+                        },
+                        "comment": {
+                          "type": "string"
+                        },
+                        "answer": {
+                          "default": [],
+                          "type": "array",
+                          "items": {
+                            "type": "object",
+                            "properties": {
+                              "licenseId": {
+                                "default": "",
+                                "type": "string"
+                              },
+                              "licenseName": {
+                                "default": "",
+                                "type": "string"
+                              }
+                            },
+                            "required": [
+                              "licenseId",
+                              "licenseName"
+                            ],
+                            "additionalProperties": false
+                          }
+                        },
+                        "commonStandardId": {
+                          "type": "string",
+                          "const": "license_ref"
+                        }
+                      },
+                      "required": [
+                        "type",
+                        "meta",
+                        "answer",
+                        "commonStandardId"
                       ],
                       "additionalProperties": false
                     },
@@ -1044,51 +1140,15 @@
                           "type": "string"
                         },
                         "commonStandardId": {
-                          "type": "string"
-                        }
-                      },
-                      "required": [
-                        "type",
-                        "meta",
-                        "answer"
-                      ],
-                      "additionalProperties": false
-                    },
-                    {
-                      "type": "object",
-                      "properties": {
-                        "type": {
                           "type": "string",
-                          "const": "textArea"
-                        },
-                        "meta": {
-                          "type": "object",
-                          "properties": {
-                            "schemaVersion": {
-                              "default": "1.0",
-                              "type": "string"
-                            }
-                          },
-                          "required": [
-                            "schemaVersion"
-                          ],
-                          "additionalProperties": false
-                        },
-                        "comment": {
-                          "type": "string"
-                        },
-                        "answer": {
-                          "default": "",
-                          "type": "string"
-                        },
-                        "commonStandardId": {
-                          "type": "string"
+                          "const": "custom"
                         }
                       },
                       "required": [
                         "type",
                         "meta",
-                        "answer"
+                        "answer",
+                        "commonStandardId"
                       ],
                       "additionalProperties": false
                     }

--- a/schemas/anyQuestion.schema.json
+++ b/schemas/anyQuestion.schema.json
@@ -1544,7 +1544,8 @@
                     "additionalProperties": false
                   },
                   "commonStandardId": {
-                    "type": "string"
+                    "type": "string",
+                    "const": "title"
                   }
                 },
                 "required": [
@@ -1552,7 +1553,8 @@
                   "help",
                   "required",
                   "enabled",
-                  "content"
+                  "content",
+                  "commonStandardId"
                 ],
                 "additionalProperties": false
               },
@@ -1656,7 +1658,8 @@
                     "additionalProperties": false
                   },
                   "commonStandardId": {
-                    "type": "string"
+                    "type": "string",
+                    "const": "description"
                   }
                 },
                 "required": [
@@ -1664,7 +1667,8 @@
                   "help",
                   "required",
                   "enabled",
-                  "content"
+                  "content",
+                  "commonStandardId"
                 ],
                 "additionalProperties": false
               },
@@ -1776,7 +1780,8 @@
                     "additionalProperties": false
                   },
                   "commonStandardId": {
-                    "type": "string"
+                    "type": "string",
+                    "const": "type"
                   }
                 },
                 "required": [
@@ -1784,7 +1789,8 @@
                   "help",
                   "required",
                   "enabled",
-                  "content"
+                  "content",
+                  "commonStandardId"
                 ],
                 "additionalProperties": false
               },
@@ -1889,7 +1895,8 @@
                     "additionalProperties": false
                   },
                   "commonStandardId": {
-                    "type": "string"
+                    "type": "string",
+                    "const": "data_flags"
                   }
                 },
                 "required": [
@@ -1897,7 +1904,8 @@
                   "help",
                   "required",
                   "enabled",
-                  "content"
+                  "content",
+                  "commonStandardId"
                 ],
                 "additionalProperties": false
               },
@@ -2002,7 +2010,8 @@
                     "additionalProperties": false
                   },
                   "commonStandardId": {
-                    "type": "string"
+                    "type": "string",
+                    "const": "data_access"
                   }
                 },
                 "required": [
@@ -2010,7 +2019,8 @@
                   "help",
                   "required",
                   "enabled",
-                  "content"
+                  "content",
+                  "commonStandardId"
                 ],
                 "additionalProperties": false
               },
@@ -2099,7 +2109,8 @@
                     "additionalProperties": false
                   },
                   "commonStandardId": {
-                    "type": "string"
+                    "type": "string",
+                    "const": "issued"
                   }
                 },
                 "required": [
@@ -2107,7 +2118,8 @@
                   "help",
                   "required",
                   "enabled",
-                  "content"
+                  "content",
+                  "commonStandardId"
                 ],
                 "additionalProperties": false
               },
@@ -2228,7 +2240,8 @@
                     "additionalProperties": false
                   },
                   "commonStandardId": {
-                    "type": "string"
+                    "type": "string",
+                    "const": "byte_size"
                   }
                 },
                 "required": [
@@ -2236,7 +2249,8 @@
                   "help",
                   "required",
                   "enabled",
-                  "content"
+                  "content",
+                  "commonStandardId"
                 ],
                 "additionalProperties": false
               },
@@ -2399,7 +2413,8 @@
                     "additionalProperties": false
                   },
                   "commonStandardId": {
-                    "type": "string"
+                    "type": "string",
+                    "const": "host"
                   },
                   "preferences": {
                     "default": [],
@@ -2430,6 +2445,7 @@
                   "required",
                   "enabled",
                   "content",
+                  "commonStandardId",
                   "preferences"
                 ],
                 "additionalProperties": false
@@ -2594,7 +2610,8 @@
                     "additionalProperties": false
                   },
                   "commonStandardId": {
-                    "type": "string"
+                    "type": "string",
+                    "const": "metadata"
                   },
                   "preferences": {
                     "default": [],
@@ -2625,6 +2642,7 @@
                   "required",
                   "enabled",
                   "content",
+                  "commonStandardId",
                   "preferences"
                 ],
                 "additionalProperties": false
@@ -2788,7 +2806,8 @@
                     "additionalProperties": false
                   },
                   "commonStandardId": {
-                    "type": "string"
+                    "type": "string",
+                    "const": "license_ref"
                   },
                   "preferences": {
                     "default": [],
@@ -2819,6 +2838,7 @@
                   "required",
                   "enabled",
                   "content",
+                  "commonStandardId",
                   "preferences"
                 ],
                 "additionalProperties": false
@@ -2902,6 +2922,10 @@
                       "meta"
                     ],
                     "additionalProperties": false
+                  },
+                  "commonStandardId": {
+                    "type": "string",
+                    "const": "custom"
                   }
                 },
                 "required": [
@@ -2909,7 +2933,8 @@
                   "help",
                   "required",
                   "enabled",
-                  "content"
+                  "content",
+                  "commonStandardId"
                 ],
                 "additionalProperties": false
               }

--- a/schemas/dmpExtension.schema.json
+++ b/schemas/dmpExtension.schema.json
@@ -748,6 +748,126 @@
                                                   "properties": {
                                                     "type": {
                                                       "type": "string",
+                                                      "const": "text"
+                                                    },
+                                                    "meta": {
+                                                      "type": "object",
+                                                      "properties": {
+                                                        "schemaVersion": {
+                                                          "default": "1.0",
+                                                          "type": "string"
+                                                        }
+                                                      },
+                                                      "required": [
+                                                        "schemaVersion"
+                                                      ],
+                                                      "additionalProperties": false
+                                                    },
+                                                    "comment": {
+                                                      "type": "string"
+                                                    },
+                                                    "answer": {
+                                                      "default": "",
+                                                      "type": "string"
+                                                    },
+                                                    "commonStandardId": {
+                                                      "type": "string",
+                                                      "const": "title"
+                                                    }
+                                                  },
+                                                  "required": [
+                                                    "type",
+                                                    "meta",
+                                                    "answer",
+                                                    "commonStandardId"
+                                                  ],
+                                                  "additionalProperties": false
+                                                },
+                                                {
+                                                  "type": "object",
+                                                  "properties": {
+                                                    "type": {
+                                                      "type": "string",
+                                                      "const": "textArea"
+                                                    },
+                                                    "meta": {
+                                                      "type": "object",
+                                                      "properties": {
+                                                        "schemaVersion": {
+                                                          "default": "1.0",
+                                                          "type": "string"
+                                                        }
+                                                      },
+                                                      "required": [
+                                                        "schemaVersion"
+                                                      ],
+                                                      "additionalProperties": false
+                                                    },
+                                                    "comment": {
+                                                      "type": "string"
+                                                    },
+                                                    "answer": {
+                                                      "default": "",
+                                                      "type": "string"
+                                                    },
+                                                    "commonStandardId": {
+                                                      "type": "string",
+                                                      "const": "description"
+                                                    }
+                                                  },
+                                                  "required": [
+                                                    "type",
+                                                    "meta",
+                                                    "answer",
+                                                    "commonStandardId"
+                                                  ],
+                                                  "additionalProperties": false
+                                                },
+                                                {
+                                                  "type": "object",
+                                                  "properties": {
+                                                    "type": {
+                                                      "type": "string",
+                                                      "const": "selectBox"
+                                                    },
+                                                    "meta": {
+                                                      "type": "object",
+                                                      "properties": {
+                                                        "schemaVersion": {
+                                                          "default": "1.0",
+                                                          "type": "string"
+                                                        }
+                                                      },
+                                                      "required": [
+                                                        "schemaVersion"
+                                                      ],
+                                                      "additionalProperties": false
+                                                    },
+                                                    "comment": {
+                                                      "type": "string"
+                                                    },
+                                                    "answer": {
+                                                      "default": "",
+                                                      "type": "string"
+                                                    },
+                                                    "commonStandardId": {
+                                                      "type": "string",
+                                                      "const": "type"
+                                                    }
+                                                  },
+                                                  "required": [
+                                                    "type",
+                                                    "meta",
+                                                    "answer",
+                                                    "commonStandardId"
+                                                  ],
+                                                  "additionalProperties": false
+                                                },
+                                                {
+                                                  "type": "object",
+                                                  "properties": {
+                                                    "type": {
+                                                      "type": "string",
                                                       "const": "checkBoxes"
                                                     },
                                                     "meta": {
@@ -776,13 +896,55 @@
                                                       }
                                                     },
                                                     "commonStandardId": {
-                                                      "type": "string"
+                                                      "type": "string",
+                                                      "const": "data_flags"
                                                     }
                                                   },
                                                   "required": [
                                                     "type",
                                                     "meta",
-                                                    "answer"
+                                                    "answer",
+                                                    "commonStandardId"
+                                                  ],
+                                                  "additionalProperties": false
+                                                },
+                                                {
+                                                  "type": "object",
+                                                  "properties": {
+                                                    "type": {
+                                                      "type": "string",
+                                                      "const": "radioButtons"
+                                                    },
+                                                    "meta": {
+                                                      "type": "object",
+                                                      "properties": {
+                                                        "schemaVersion": {
+                                                          "default": "1.0",
+                                                          "type": "string"
+                                                        }
+                                                      },
+                                                      "required": [
+                                                        "schemaVersion"
+                                                      ],
+                                                      "additionalProperties": false
+                                                    },
+                                                    "comment": {
+                                                      "type": "string"
+                                                    },
+                                                    "answer": {
+                                                      "default": "",
+                                                      "type": "string"
+                                                    },
+                                                    "commonStandardId": {
+                                                      "type": "string",
+                                                      "const": "data_access"
+                                                    }
+                                                  },
+                                                  "required": [
+                                                    "type",
+                                                    "meta",
+                                                    "answer",
+                                                    "commonStandardId"
                                                   ],
                                                   "additionalProperties": false
                                                 },
@@ -814,125 +976,15 @@
                                                       "type": "string"
                                                     },
                                                     "commonStandardId": {
-                                                      "type": "string"
-                                                    }
-                                                  },
-                                                  "required": [
-                                                    "type",
-                                                    "meta",
-                                                    "answer"
-                                                  ],
-                                                  "additionalProperties": false
-                                                },
-                                                {
-                                                  "type": "object",
-                                                  "properties": {
-                                                    "type": {
                                                       "type": "string",
-                                                      "const": "licenseSearch"
-                                                    },
-                                                    "meta": {
-                                                      "type": "object",
-                                                      "properties": {
-                                                        "schemaVersion": {
-                                                          "default": "1.0",
-                                                          "type": "string"
-                                                        }
-                                                      },
-                                                      "required": [
-                                                        "schemaVersion"
-                                                      ],
-                                                      "additionalProperties": false
-                                                    },
-                                                    "comment": {
-                                                      "type": "string"
-                                                    },
-                                                    "answer": {
-                                                      "default": [],
-                                                      "type": "array",
-                                                      "items": {
-                                                        "type": "object",
-                                                        "properties": {
-                                                          "licenseId": {
-                                                            "default": "",
-                                                            "type": "string"
-                                                          },
-                                                          "licenseName": {
-                                                            "default": "",
-                                                            "type": "string"
-                                                          }
-                                                        },
-                                                        "required": [
-                                                          "licenseId",
-                                                          "licenseName"
-                                                        ],
-                                                        "additionalProperties": false
-                                                      }
-                                                    },
-                                                    "commonStandardId": {
-                                                      "type": "string"
+                                                      "const": "issued"
                                                     }
                                                   },
                                                   "required": [
                                                     "type",
                                                     "meta",
-                                                    "answer"
-                                                  ],
-                                                  "additionalProperties": false
-                                                },
-                                                {
-                                                  "type": "object",
-                                                  "properties": {
-                                                    "type": {
-                                                      "type": "string",
-                                                      "const": "metadataStandardSearch"
-                                                    },
-                                                    "meta": {
-                                                      "type": "object",
-                                                      "properties": {
-                                                        "schemaVersion": {
-                                                          "default": "1.0",
-                                                          "type": "string"
-                                                        }
-                                                      },
-                                                      "required": [
-                                                        "schemaVersion"
-                                                      ],
-                                                      "additionalProperties": false
-                                                    },
-                                                    "comment": {
-                                                      "type": "string"
-                                                    },
-                                                    "answer": {
-                                                      "default": [],
-                                                      "type": "array",
-                                                      "items": {
-                                                        "type": "object",
-                                                        "properties": {
-                                                          "metadataStandardId": {
-                                                            "default": "",
-                                                            "type": "string"
-                                                          },
-                                                          "metadataStandardName": {
-                                                            "default": "",
-                                                            "type": "string"
-                                                          }
-                                                        },
-                                                        "required": [
-                                                          "metadataStandardId",
-                                                          "metadataStandardName"
-                                                        ],
-                                                        "additionalProperties": false
-                                                      }
-                                                    },
-                                                    "commonStandardId": {
-                                                      "type": "string"
-                                                    }
-                                                  },
-                                                  "required": [
-                                                    "type",
-                                                    "meta",
-                                                    "answer"
+                                                    "answer",
+                                                    "commonStandardId"
                                                   ],
                                                   "additionalProperties": false
                                                 },
@@ -978,51 +1030,15 @@
                                                       "additionalProperties": false
                                                     },
                                                     "commonStandardId": {
-                                                      "type": "string"
-                                                    }
-                                                  },
-                                                  "required": [
-                                                    "type",
-                                                    "meta",
-                                                    "answer"
-                                                  ],
-                                                  "additionalProperties": false
-                                                },
-                                                {
-                                                  "type": "object",
-                                                  "properties": {
-                                                    "type": {
                                                       "type": "string",
-                                                      "const": "radioButtons"
-                                                    },
-                                                    "meta": {
-                                                      "type": "object",
-                                                      "properties": {
-                                                        "schemaVersion": {
-                                                          "default": "1.0",
-                                                          "type": "string"
-                                                        }
-                                                      },
-                                                      "required": [
-                                                        "schemaVersion"
-                                                      ],
-                                                      "additionalProperties": false
-                                                    },
-                                                    "comment": {
-                                                      "type": "string"
-                                                    },
-                                                    "answer": {
-                                                      "default": "",
-                                                      "type": "string"
-                                                    },
-                                                    "commonStandardId": {
-                                                      "type": "string"
+                                                      "const": "byte_size"
                                                     }
                                                   },
                                                   "required": [
                                                     "type",
                                                     "meta",
-                                                    "answer"
+                                                    "answer",
+                                                    "commonStandardId"
                                                   ],
                                                   "additionalProperties": false
                                                 },
@@ -1072,13 +1088,15 @@
                                                       }
                                                     },
                                                     "commonStandardId": {
-                                                      "type": "string"
+                                                      "type": "string",
+                                                      "const": "host"
                                                     }
                                                   },
                                                   "required": [
                                                     "type",
                                                     "meta",
-                                                    "answer"
+                                                    "answer",
+                                                    "commonStandardId"
                                                   ],
                                                   "additionalProperties": false
                                                 },
@@ -1087,7 +1105,7 @@
                                                   "properties": {
                                                     "type": {
                                                       "type": "string",
-                                                      "const": "selectBox"
+                                                      "const": "metadataStandardSearch"
                                                     },
                                                     "meta": {
                                                       "type": "object",
@@ -1106,17 +1124,95 @@
                                                       "type": "string"
                                                     },
                                                     "answer": {
-                                                      "default": "",
-                                                      "type": "string"
+                                                      "default": [],
+                                                      "type": "array",
+                                                      "items": {
+                                                        "type": "object",
+                                                        "properties": {
+                                                          "metadataStandardId": {
+                                                            "default": "",
+                                                            "type": "string"
+                                                          },
+                                                          "metadataStandardName": {
+                                                            "default": "",
+                                                            "type": "string"
+                                                          }
+                                                        },
+                                                        "required": [
+                                                          "metadataStandardId",
+                                                          "metadataStandardName"
+                                                        ],
+                                                        "additionalProperties": false
+                                                      }
                                                     },
                                                     "commonStandardId": {
-                                                      "type": "string"
+                                                      "type": "string",
+                                                      "const": "metadata"
                                                     }
                                                   },
                                                   "required": [
                                                     "type",
                                                     "meta",
-                                                    "answer"
+                                                    "answer",
+                                                    "commonStandardId"
+                                                  ],
+                                                  "additionalProperties": false
+                                                },
+                                                {
+                                                  "type": "object",
+                                                  "properties": {
+                                                    "type": {
+                                                      "type": "string",
+                                                      "const": "licenseSearch"
+                                                    },
+                                                    "meta": {
+                                                      "type": "object",
+                                                      "properties": {
+                                                        "schemaVersion": {
+                                                          "default": "1.0",
+                                                          "type": "string"
+                                                        }
+                                                      },
+                                                      "required": [
+                                                        "schemaVersion"
+                                                      ],
+                                                      "additionalProperties": false
+                                                    },
+                                                    "comment": {
+                                                      "type": "string"
+                                                    },
+                                                    "answer": {
+                                                      "default": [],
+                                                      "type": "array",
+                                                      "items": {
+                                                        "type": "object",
+                                                        "properties": {
+                                                          "licenseId": {
+                                                            "default": "",
+                                                            "type": "string"
+                                                          },
+                                                          "licenseName": {
+                                                            "default": "",
+                                                            "type": "string"
+                                                          }
+                                                        },
+                                                        "required": [
+                                                          "licenseId",
+                                                          "licenseName"
+                                                        ],
+                                                        "additionalProperties": false
+                                                      }
+                                                    },
+                                                    "commonStandardId": {
+                                                      "type": "string",
+                                                      "const": "license_ref"
+                                                    }
+                                                  },
+                                                  "required": [
+                                                    "type",
+                                                    "meta",
+                                                    "answer",
+                                                    "commonStandardId"
                                                   ],
                                                   "additionalProperties": false
                                                 },
@@ -1148,51 +1244,15 @@
                                                       "type": "string"
                                                     },
                                                     "commonStandardId": {
-                                                      "type": "string"
-                                                    }
-                                                  },
-                                                  "required": [
-                                                    "type",
-                                                    "meta",
-                                                    "answer"
-                                                  ],
-                                                  "additionalProperties": false
-                                                },
-                                                {
-                                                  "type": "object",
-                                                  "properties": {
-                                                    "type": {
                                                       "type": "string",
-                                                      "const": "textArea"
-                                                    },
-                                                    "meta": {
-                                                      "type": "object",
-                                                      "properties": {
-                                                        "schemaVersion": {
-                                                          "default": "1.0",
-                                                          "type": "string"
-                                                        }
-                                                      },
-                                                      "required": [
-                                                        "schemaVersion"
-                                                      ],
-                                                      "additionalProperties": false
-                                                    },
-                                                    "comment": {
-                                                      "type": "string"
-                                                    },
-                                                    "answer": {
-                                                      "default": "",
-                                                      "type": "string"
-                                                    },
-                                                    "commonStandardId": {
-                                                      "type": "string"
+                                                      "const": "custom"
                                                     }
                                                   },
                                                   "required": [
                                                     "type",
                                                     "meta",
-                                                    "answer"
+                                                    "answer",
+                                                    "commonStandardId"
                                                   ],
                                                   "additionalProperties": false
                                                 }

--- a/schemas/dmptoolDmp.schema.json
+++ b/schemas/dmptoolDmp.schema.json
@@ -2805,6 +2805,126 @@
                                                       "properties": {
                                                         "type": {
                                                           "type": "string",
+                                                          "const": "text"
+                                                        },
+                                                        "meta": {
+                                                          "type": "object",
+                                                          "properties": {
+                                                            "schemaVersion": {
+                                                              "default": "1.0",
+                                                              "type": "string"
+                                                            }
+                                                          },
+                                                          "required": [
+                                                            "schemaVersion"
+                                                          ],
+                                                          "additionalProperties": false
+                                                        },
+                                                        "comment": {
+                                                          "type": "string"
+                                                        },
+                                                        "answer": {
+                                                          "default": "",
+                                                          "type": "string"
+                                                        },
+                                                        "commonStandardId": {
+                                                          "type": "string",
+                                                          "const": "title"
+                                                        }
+                                                      },
+                                                      "required": [
+                                                        "type",
+                                                        "meta",
+                                                        "answer",
+                                                        "commonStandardId"
+                                                      ],
+                                                      "additionalProperties": false
+                                                    },
+                                                    {
+                                                      "type": "object",
+                                                      "properties": {
+                                                        "type": {
+                                                          "type": "string",
+                                                          "const": "textArea"
+                                                        },
+                                                        "meta": {
+                                                          "type": "object",
+                                                          "properties": {
+                                                            "schemaVersion": {
+                                                              "default": "1.0",
+                                                              "type": "string"
+                                                            }
+                                                          },
+                                                          "required": [
+                                                            "schemaVersion"
+                                                          ],
+                                                          "additionalProperties": false
+                                                        },
+                                                        "comment": {
+                                                          "type": "string"
+                                                        },
+                                                        "answer": {
+                                                          "default": "",
+                                                          "type": "string"
+                                                        },
+                                                        "commonStandardId": {
+                                                          "type": "string",
+                                                          "const": "description"
+                                                        }
+                                                      },
+                                                      "required": [
+                                                        "type",
+                                                        "meta",
+                                                        "answer",
+                                                        "commonStandardId"
+                                                      ],
+                                                      "additionalProperties": false
+                                                    },
+                                                    {
+                                                      "type": "object",
+                                                      "properties": {
+                                                        "type": {
+                                                          "type": "string",
+                                                          "const": "selectBox"
+                                                        },
+                                                        "meta": {
+                                                          "type": "object",
+                                                          "properties": {
+                                                            "schemaVersion": {
+                                                              "default": "1.0",
+                                                              "type": "string"
+                                                            }
+                                                          },
+                                                          "required": [
+                                                            "schemaVersion"
+                                                          ],
+                                                          "additionalProperties": false
+                                                        },
+                                                        "comment": {
+                                                          "type": "string"
+                                                        },
+                                                        "answer": {
+                                                          "default": "",
+                                                          "type": "string"
+                                                        },
+                                                        "commonStandardId": {
+                                                          "type": "string",
+                                                          "const": "type"
+                                                        }
+                                                      },
+                                                      "required": [
+                                                        "type",
+                                                        "meta",
+                                                        "answer",
+                                                        "commonStandardId"
+                                                      ],
+                                                      "additionalProperties": false
+                                                    },
+                                                    {
+                                                      "type": "object",
+                                                      "properties": {
+                                                        "type": {
+                                                          "type": "string",
                                                           "const": "checkBoxes"
                                                         },
                                                         "meta": {
@@ -2833,13 +2953,55 @@
                                                           }
                                                         },
                                                         "commonStandardId": {
-                                                          "type": "string"
+                                                          "type": "string",
+                                                          "const": "data_flags"
                                                         }
                                                       },
                                                       "required": [
                                                         "type",
                                                         "meta",
-                                                        "answer"
+                                                        "answer",
+                                                        "commonStandardId"
+                                                      ],
+                                                      "additionalProperties": false
+                                                    },
+                                                    {
+                                                      "type": "object",
+                                                      "properties": {
+                                                        "type": {
+                                                          "type": "string",
+                                                          "const": "radioButtons"
+                                                        },
+                                                        "meta": {
+                                                          "type": "object",
+                                                          "properties": {
+                                                            "schemaVersion": {
+                                                              "default": "1.0",
+                                                              "type": "string"
+                                                            }
+                                                          },
+                                                          "required": [
+                                                            "schemaVersion"
+                                                          ],
+                                                          "additionalProperties": false
+                                                        },
+                                                        "comment": {
+                                                          "type": "string"
+                                                        },
+                                                        "answer": {
+                                                          "default": "",
+                                                          "type": "string"
+                                                        },
+                                                        "commonStandardId": {
+                                                          "type": "string",
+                                                          "const": "data_access"
+                                                        }
+                                                      },
+                                                      "required": [
+                                                        "type",
+                                                        "meta",
+                                                        "answer",
+                                                        "commonStandardId"
                                                       ],
                                                       "additionalProperties": false
                                                     },
@@ -2871,125 +3033,15 @@
                                                           "type": "string"
                                                         },
                                                         "commonStandardId": {
-                                                          "type": "string"
-                                                        }
-                                                      },
-                                                      "required": [
-                                                        "type",
-                                                        "meta",
-                                                        "answer"
-                                                      ],
-                                                      "additionalProperties": false
-                                                    },
-                                                    {
-                                                      "type": "object",
-                                                      "properties": {
-                                                        "type": {
                                                           "type": "string",
-                                                          "const": "licenseSearch"
-                                                        },
-                                                        "meta": {
-                                                          "type": "object",
-                                                          "properties": {
-                                                            "schemaVersion": {
-                                                              "default": "1.0",
-                                                              "type": "string"
-                                                            }
-                                                          },
-                                                          "required": [
-                                                            "schemaVersion"
-                                                          ],
-                                                          "additionalProperties": false
-                                                        },
-                                                        "comment": {
-                                                          "type": "string"
-                                                        },
-                                                        "answer": {
-                                                          "default": [],
-                                                          "type": "array",
-                                                          "items": {
-                                                            "type": "object",
-                                                            "properties": {
-                                                              "licenseId": {
-                                                                "default": "",
-                                                                "type": "string"
-                                                              },
-                                                              "licenseName": {
-                                                                "default": "",
-                                                                "type": "string"
-                                                              }
-                                                            },
-                                                            "required": [
-                                                              "licenseId",
-                                                              "licenseName"
-                                                            ],
-                                                            "additionalProperties": false
-                                                          }
-                                                        },
-                                                        "commonStandardId": {
-                                                          "type": "string"
+                                                          "const": "issued"
                                                         }
                                                       },
                                                       "required": [
                                                         "type",
                                                         "meta",
-                                                        "answer"
-                                                      ],
-                                                      "additionalProperties": false
-                                                    },
-                                                    {
-                                                      "type": "object",
-                                                      "properties": {
-                                                        "type": {
-                                                          "type": "string",
-                                                          "const": "metadataStandardSearch"
-                                                        },
-                                                        "meta": {
-                                                          "type": "object",
-                                                          "properties": {
-                                                            "schemaVersion": {
-                                                              "default": "1.0",
-                                                              "type": "string"
-                                                            }
-                                                          },
-                                                          "required": [
-                                                            "schemaVersion"
-                                                          ],
-                                                          "additionalProperties": false
-                                                        },
-                                                        "comment": {
-                                                          "type": "string"
-                                                        },
-                                                        "answer": {
-                                                          "default": [],
-                                                          "type": "array",
-                                                          "items": {
-                                                            "type": "object",
-                                                            "properties": {
-                                                              "metadataStandardId": {
-                                                                "default": "",
-                                                                "type": "string"
-                                                              },
-                                                              "metadataStandardName": {
-                                                                "default": "",
-                                                                "type": "string"
-                                                              }
-                                                            },
-                                                            "required": [
-                                                              "metadataStandardId",
-                                                              "metadataStandardName"
-                                                            ],
-                                                            "additionalProperties": false
-                                                          }
-                                                        },
-                                                        "commonStandardId": {
-                                                          "type": "string"
-                                                        }
-                                                      },
-                                                      "required": [
-                                                        "type",
-                                                        "meta",
-                                                        "answer"
+                                                        "answer",
+                                                        "commonStandardId"
                                                       ],
                                                       "additionalProperties": false
                                                     },
@@ -3035,51 +3087,15 @@
                                                           "additionalProperties": false
                                                         },
                                                         "commonStandardId": {
-                                                          "type": "string"
-                                                        }
-                                                      },
-                                                      "required": [
-                                                        "type",
-                                                        "meta",
-                                                        "answer"
-                                                      ],
-                                                      "additionalProperties": false
-                                                    },
-                                                    {
-                                                      "type": "object",
-                                                      "properties": {
-                                                        "type": {
                                                           "type": "string",
-                                                          "const": "radioButtons"
-                                                        },
-                                                        "meta": {
-                                                          "type": "object",
-                                                          "properties": {
-                                                            "schemaVersion": {
-                                                              "default": "1.0",
-                                                              "type": "string"
-                                                            }
-                                                          },
-                                                          "required": [
-                                                            "schemaVersion"
-                                                          ],
-                                                          "additionalProperties": false
-                                                        },
-                                                        "comment": {
-                                                          "type": "string"
-                                                        },
-                                                        "answer": {
-                                                          "default": "",
-                                                          "type": "string"
-                                                        },
-                                                        "commonStandardId": {
-                                                          "type": "string"
+                                                          "const": "byte_size"
                                                         }
                                                       },
                                                       "required": [
                                                         "type",
                                                         "meta",
-                                                        "answer"
+                                                        "answer",
+                                                        "commonStandardId"
                                                       ],
                                                       "additionalProperties": false
                                                     },
@@ -3129,13 +3145,15 @@
                                                           }
                                                         },
                                                         "commonStandardId": {
-                                                          "type": "string"
+                                                          "type": "string",
+                                                          "const": "host"
                                                         }
                                                       },
                                                       "required": [
                                                         "type",
                                                         "meta",
-                                                        "answer"
+                                                        "answer",
+                                                        "commonStandardId"
                                                       ],
                                                       "additionalProperties": false
                                                     },
@@ -3144,7 +3162,7 @@
                                                       "properties": {
                                                         "type": {
                                                           "type": "string",
-                                                          "const": "selectBox"
+                                                          "const": "metadataStandardSearch"
                                                         },
                                                         "meta": {
                                                           "type": "object",
@@ -3163,17 +3181,95 @@
                                                           "type": "string"
                                                         },
                                                         "answer": {
-                                                          "default": "",
-                                                          "type": "string"
+                                                          "default": [],
+                                                          "type": "array",
+                                                          "items": {
+                                                            "type": "object",
+                                                            "properties": {
+                                                              "metadataStandardId": {
+                                                                "default": "",
+                                                                "type": "string"
+                                                              },
+                                                              "metadataStandardName": {
+                                                                "default": "",
+                                                                "type": "string"
+                                                              }
+                                                            },
+                                                            "required": [
+                                                              "metadataStandardId",
+                                                              "metadataStandardName"
+                                                            ],
+                                                            "additionalProperties": false
+                                                          }
                                                         },
                                                         "commonStandardId": {
-                                                          "type": "string"
+                                                          "type": "string",
+                                                          "const": "metadata"
                                                         }
                                                       },
                                                       "required": [
                                                         "type",
                                                         "meta",
-                                                        "answer"
+                                                        "answer",
+                                                        "commonStandardId"
+                                                      ],
+                                                      "additionalProperties": false
+                                                    },
+                                                    {
+                                                      "type": "object",
+                                                      "properties": {
+                                                        "type": {
+                                                          "type": "string",
+                                                          "const": "licenseSearch"
+                                                        },
+                                                        "meta": {
+                                                          "type": "object",
+                                                          "properties": {
+                                                            "schemaVersion": {
+                                                              "default": "1.0",
+                                                              "type": "string"
+                                                            }
+                                                          },
+                                                          "required": [
+                                                            "schemaVersion"
+                                                          ],
+                                                          "additionalProperties": false
+                                                        },
+                                                        "comment": {
+                                                          "type": "string"
+                                                        },
+                                                        "answer": {
+                                                          "default": [],
+                                                          "type": "array",
+                                                          "items": {
+                                                            "type": "object",
+                                                            "properties": {
+                                                              "licenseId": {
+                                                                "default": "",
+                                                                "type": "string"
+                                                              },
+                                                              "licenseName": {
+                                                                "default": "",
+                                                                "type": "string"
+                                                              }
+                                                            },
+                                                            "required": [
+                                                              "licenseId",
+                                                              "licenseName"
+                                                            ],
+                                                            "additionalProperties": false
+                                                          }
+                                                        },
+                                                        "commonStandardId": {
+                                                          "type": "string",
+                                                          "const": "license_ref"
+                                                        }
+                                                      },
+                                                      "required": [
+                                                        "type",
+                                                        "meta",
+                                                        "answer",
+                                                        "commonStandardId"
                                                       ],
                                                       "additionalProperties": false
                                                     },
@@ -3205,51 +3301,15 @@
                                                           "type": "string"
                                                         },
                                                         "commonStandardId": {
-                                                          "type": "string"
-                                                        }
-                                                      },
-                                                      "required": [
-                                                        "type",
-                                                        "meta",
-                                                        "answer"
-                                                      ],
-                                                      "additionalProperties": false
-                                                    },
-                                                    {
-                                                      "type": "object",
-                                                      "properties": {
-                                                        "type": {
                                                           "type": "string",
-                                                          "const": "textArea"
-                                                        },
-                                                        "meta": {
-                                                          "type": "object",
-                                                          "properties": {
-                                                            "schemaVersion": {
-                                                              "default": "1.0",
-                                                              "type": "string"
-                                                            }
-                                                          },
-                                                          "required": [
-                                                            "schemaVersion"
-                                                          ],
-                                                          "additionalProperties": false
-                                                        },
-                                                        "comment": {
-                                                          "type": "string"
-                                                        },
-                                                        "answer": {
-                                                          "default": "",
-                                                          "type": "string"
-                                                        },
-                                                        "commonStandardId": {
-                                                          "type": "string"
+                                                          "const": "custom"
                                                         }
                                                       },
                                                       "required": [
                                                         "type",
                                                         "meta",
-                                                        "answer"
+                                                        "answer",
+                                                        "commonStandardId"
                                                       ],
                                                       "additionalProperties": false
                                                     }

--- a/schemas/researchOutputTableAnswer.schema.json
+++ b/schemas/researchOutputTableAnswer.schema.json
@@ -107,6 +107,255 @@
                                   "def": {
                                     "type": "literal",
                                     "values": [
+                                      "text"
+                                    ]
+                                  },
+                                  "type": "literal",
+                                  "values": {}
+                                },
+                                "meta": {
+                                  "def": {
+                                    "type": "object",
+                                    "shape": {
+                                      "schemaVersion": {
+                                        "def": {
+                                          "type": "default",
+                                          "innerType": {
+                                            "def": {
+                                              "type": "string"
+                                            },
+                                            "type": "string",
+                                            "format": null,
+                                            "minLength": null,
+                                            "maxLength": null
+                                          },
+                                          "defaultValue": "1.0"
+                                        },
+                                        "type": "default"
+                                      }
+                                    }
+                                  },
+                                  "type": "object"
+                                },
+                                "comment": {
+                                  "def": {
+                                    "type": "optional",
+                                    "innerType": {
+                                      "def": {
+                                        "type": "string"
+                                      },
+                                      "type": "string",
+                                      "format": null,
+                                      "minLength": null,
+                                      "maxLength": null
+                                    }
+                                  },
+                                  "type": "optional"
+                                },
+                                "answer": {
+                                  "def": {
+                                    "type": "default",
+                                    "innerType": {
+                                      "def": {
+                                        "type": "string"
+                                      },
+                                      "type": "string",
+                                      "format": null,
+                                      "minLength": null,
+                                      "maxLength": null
+                                    },
+                                    "defaultValue": ""
+                                  },
+                                  "type": "default"
+                                },
+                                "commonStandardId": {
+                                  "def": {
+                                    "type": "literal",
+                                    "values": [
+                                      "title"
+                                    ]
+                                  },
+                                  "type": "literal",
+                                  "values": {}
+                                }
+                              }
+                            },
+                            "type": "object"
+                          },
+                          {
+                            "def": {
+                              "type": "object",
+                              "shape": {
+                                "type": {
+                                  "def": {
+                                    "type": "literal",
+                                    "values": [
+                                      "textArea"
+                                    ]
+                                  },
+                                  "type": "literal",
+                                  "values": {}
+                                },
+                                "meta": {
+                                  "def": {
+                                    "type": "object",
+                                    "shape": {
+                                      "schemaVersion": {
+                                        "def": {
+                                          "type": "default",
+                                          "innerType": {
+                                            "def": {
+                                              "type": "string"
+                                            },
+                                            "type": "string",
+                                            "format": null,
+                                            "minLength": null,
+                                            "maxLength": null
+                                          },
+                                          "defaultValue": "1.0"
+                                        },
+                                        "type": "default"
+                                      }
+                                    }
+                                  },
+                                  "type": "object"
+                                },
+                                "comment": {
+                                  "def": {
+                                    "type": "optional",
+                                    "innerType": {
+                                      "def": {
+                                        "type": "string"
+                                      },
+                                      "type": "string",
+                                      "format": null,
+                                      "minLength": null,
+                                      "maxLength": null
+                                    }
+                                  },
+                                  "type": "optional"
+                                },
+                                "answer": {
+                                  "def": {
+                                    "type": "default",
+                                    "innerType": {
+                                      "def": {
+                                        "type": "string"
+                                      },
+                                      "type": "string",
+                                      "format": null,
+                                      "minLength": null,
+                                      "maxLength": null
+                                    },
+                                    "defaultValue": ""
+                                  },
+                                  "type": "default"
+                                },
+                                "commonStandardId": {
+                                  "def": {
+                                    "type": "literal",
+                                    "values": [
+                                      "description"
+                                    ]
+                                  },
+                                  "type": "literal",
+                                  "values": {}
+                                }
+                              }
+                            },
+                            "type": "object"
+                          },
+                          {
+                            "def": {
+                              "type": "object",
+                              "shape": {
+                                "type": {
+                                  "def": {
+                                    "type": "literal",
+                                    "values": [
+                                      "selectBox"
+                                    ]
+                                  },
+                                  "type": "literal",
+                                  "values": {}
+                                },
+                                "meta": {
+                                  "def": {
+                                    "type": "object",
+                                    "shape": {
+                                      "schemaVersion": {
+                                        "def": {
+                                          "type": "default",
+                                          "innerType": {
+                                            "def": {
+                                              "type": "string"
+                                            },
+                                            "type": "string",
+                                            "format": null,
+                                            "minLength": null,
+                                            "maxLength": null
+                                          },
+                                          "defaultValue": "1.0"
+                                        },
+                                        "type": "default"
+                                      }
+                                    }
+                                  },
+                                  "type": "object"
+                                },
+                                "comment": {
+                                  "def": {
+                                    "type": "optional",
+                                    "innerType": {
+                                      "def": {
+                                        "type": "string"
+                                      },
+                                      "type": "string",
+                                      "format": null,
+                                      "minLength": null,
+                                      "maxLength": null
+                                    }
+                                  },
+                                  "type": "optional"
+                                },
+                                "answer": {
+                                  "def": {
+                                    "type": "default",
+                                    "innerType": {
+                                      "def": {
+                                        "type": "string"
+                                      },
+                                      "type": "string",
+                                      "format": null,
+                                      "minLength": null,
+                                      "maxLength": null
+                                    },
+                                    "defaultValue": ""
+                                  },
+                                  "type": "default"
+                                },
+                                "commonStandardId": {
+                                  "def": {
+                                    "type": "literal",
+                                    "values": [
+                                      "type"
+                                    ]
+                                  },
+                                  "type": "literal",
+                                  "values": {}
+                                }
+                              }
+                            },
+                            "type": "object"
+                          },
+                          {
+                            "def": {
+                              "type": "object",
+                              "shape": {
+                                "type": {
+                                  "def": {
+                                    "type": "literal",
+                                    "values": [
                                       "checkBoxes"
                                     ]
                                   },
@@ -187,6 +436,58 @@
                                 },
                                 "commonStandardId": {
                                   "def": {
+                                    "type": "literal",
+                                    "values": [
+                                      "data_flags"
+                                    ]
+                                  },
+                                  "type": "literal",
+                                  "values": {}
+                                }
+                              }
+                            },
+                            "type": "object"
+                          },
+                          {
+                            "def": {
+                              "type": "object",
+                              "shape": {
+                                "type": {
+                                  "def": {
+                                    "type": "literal",
+                                    "values": [
+                                      "radioButtons"
+                                    ]
+                                  },
+                                  "type": "literal",
+                                  "values": {}
+                                },
+                                "meta": {
+                                  "def": {
+                                    "type": "object",
+                                    "shape": {
+                                      "schemaVersion": {
+                                        "def": {
+                                          "type": "default",
+                                          "innerType": {
+                                            "def": {
+                                              "type": "string"
+                                            },
+                                            "type": "string",
+                                            "format": null,
+                                            "minLength": null,
+                                            "maxLength": null
+                                          },
+                                          "defaultValue": "1.0"
+                                        },
+                                        "type": "default"
+                                      }
+                                    }
+                                  },
+                                  "type": "object"
+                                },
+                                "comment": {
+                                  "def": {
                                     "type": "optional",
                                     "innerType": {
                                       "def": {
@@ -199,6 +500,32 @@
                                     }
                                   },
                                   "type": "optional"
+                                },
+                                "answer": {
+                                  "def": {
+                                    "type": "default",
+                                    "innerType": {
+                                      "def": {
+                                        "type": "string"
+                                      },
+                                      "type": "string",
+                                      "format": null,
+                                      "minLength": null,
+                                      "maxLength": null
+                                    },
+                                    "defaultValue": ""
+                                  },
+                                  "type": "default"
+                                },
+                                "commonStandardId": {
+                                  "def": {
+                                    "type": "literal",
+                                    "values": [
+                                      "data_access"
+                                    ]
+                                  },
+                                  "type": "literal",
+                                  "values": {}
                                 }
                               }
                             },
@@ -275,348 +602,13 @@
                                 },
                                 "commonStandardId": {
                                   "def": {
-                                    "type": "optional",
-                                    "innerType": {
-                                      "def": {
-                                        "type": "string"
-                                      },
-                                      "type": "string",
-                                      "format": null,
-                                      "minLength": null,
-                                      "maxLength": null
-                                    }
-                                  },
-                                  "type": "optional"
-                                }
-                              }
-                            },
-                            "type": "object"
-                          },
-                          {
-                            "def": {
-                              "type": "object",
-                              "shape": {
-                                "type": {
-                                  "def": {
                                     "type": "literal",
                                     "values": [
-                                      "licenseSearch"
+                                      "issued"
                                     ]
                                   },
                                   "type": "literal",
                                   "values": {}
-                                },
-                                "meta": {
-                                  "def": {
-                                    "type": "object",
-                                    "shape": {
-                                      "schemaVersion": {
-                                        "def": {
-                                          "type": "default",
-                                          "innerType": {
-                                            "def": {
-                                              "type": "string"
-                                            },
-                                            "type": "string",
-                                            "format": null,
-                                            "minLength": null,
-                                            "maxLength": null
-                                          },
-                                          "defaultValue": "1.0"
-                                        },
-                                        "type": "default"
-                                      }
-                                    }
-                                  },
-                                  "type": "object"
-                                },
-                                "comment": {
-                                  "def": {
-                                    "type": "optional",
-                                    "innerType": {
-                                      "def": {
-                                        "type": "string"
-                                      },
-                                      "type": "string",
-                                      "format": null,
-                                      "minLength": null,
-                                      "maxLength": null
-                                    }
-                                  },
-                                  "type": "optional"
-                                },
-                                "answer": {
-                                  "def": {
-                                    "type": "default",
-                                    "innerType": {
-                                      "def": {
-                                        "type": "array",
-                                        "element": {
-                                          "def": {
-                                            "type": "object",
-                                            "shape": {
-                                              "licenseId": {
-                                                "def": {
-                                                  "type": "default",
-                                                  "innerType": {
-                                                    "def": {
-                                                      "type": "string"
-                                                    },
-                                                    "type": "string",
-                                                    "format": null,
-                                                    "minLength": null,
-                                                    "maxLength": null
-                                                  },
-                                                  "defaultValue": ""
-                                                },
-                                                "type": "default"
-                                              },
-                                              "licenseName": {
-                                                "def": {
-                                                  "type": "default",
-                                                  "innerType": {
-                                                    "def": {
-                                                      "type": "string"
-                                                    },
-                                                    "type": "string",
-                                                    "format": null,
-                                                    "minLength": null,
-                                                    "maxLength": null
-                                                  },
-                                                  "defaultValue": ""
-                                                },
-                                                "type": "default"
-                                              }
-                                            }
-                                          },
-                                          "type": "object"
-                                        }
-                                      },
-                                      "type": "array",
-                                      "element": {
-                                        "def": {
-                                          "type": "object",
-                                          "shape": {
-                                            "licenseId": {
-                                              "def": {
-                                                "type": "default",
-                                                "innerType": {
-                                                  "def": {
-                                                    "type": "string"
-                                                  },
-                                                  "type": "string",
-                                                  "format": null,
-                                                  "minLength": null,
-                                                  "maxLength": null
-                                                },
-                                                "defaultValue": ""
-                                              },
-                                              "type": "default"
-                                            },
-                                            "licenseName": {
-                                              "def": {
-                                                "type": "default",
-                                                "innerType": {
-                                                  "def": {
-                                                    "type": "string"
-                                                  },
-                                                  "type": "string",
-                                                  "format": null,
-                                                  "minLength": null,
-                                                  "maxLength": null
-                                                },
-                                                "defaultValue": ""
-                                              },
-                                              "type": "default"
-                                            }
-                                          }
-                                        },
-                                        "type": "object"
-                                      }
-                                    },
-                                    "defaultValue": []
-                                  },
-                                  "type": "default"
-                                },
-                                "commonStandardId": {
-                                  "def": {
-                                    "type": "optional",
-                                    "innerType": {
-                                      "def": {
-                                        "type": "string"
-                                      },
-                                      "type": "string",
-                                      "format": null,
-                                      "minLength": null,
-                                      "maxLength": null
-                                    }
-                                  },
-                                  "type": "optional"
-                                }
-                              }
-                            },
-                            "type": "object"
-                          },
-                          {
-                            "def": {
-                              "type": "object",
-                              "shape": {
-                                "type": {
-                                  "def": {
-                                    "type": "literal",
-                                    "values": [
-                                      "metadataStandardSearch"
-                                    ]
-                                  },
-                                  "type": "literal",
-                                  "values": {}
-                                },
-                                "meta": {
-                                  "def": {
-                                    "type": "object",
-                                    "shape": {
-                                      "schemaVersion": {
-                                        "def": {
-                                          "type": "default",
-                                          "innerType": {
-                                            "def": {
-                                              "type": "string"
-                                            },
-                                            "type": "string",
-                                            "format": null,
-                                            "minLength": null,
-                                            "maxLength": null
-                                          },
-                                          "defaultValue": "1.0"
-                                        },
-                                        "type": "default"
-                                      }
-                                    }
-                                  },
-                                  "type": "object"
-                                },
-                                "comment": {
-                                  "def": {
-                                    "type": "optional",
-                                    "innerType": {
-                                      "def": {
-                                        "type": "string"
-                                      },
-                                      "type": "string",
-                                      "format": null,
-                                      "minLength": null,
-                                      "maxLength": null
-                                    }
-                                  },
-                                  "type": "optional"
-                                },
-                                "answer": {
-                                  "def": {
-                                    "type": "default",
-                                    "innerType": {
-                                      "def": {
-                                        "type": "array",
-                                        "element": {
-                                          "def": {
-                                            "type": "object",
-                                            "shape": {
-                                              "metadataStandardId": {
-                                                "def": {
-                                                  "type": "default",
-                                                  "innerType": {
-                                                    "def": {
-                                                      "type": "string"
-                                                    },
-                                                    "type": "string",
-                                                    "format": null,
-                                                    "minLength": null,
-                                                    "maxLength": null
-                                                  },
-                                                  "defaultValue": ""
-                                                },
-                                                "type": "default"
-                                              },
-                                              "metadataStandardName": {
-                                                "def": {
-                                                  "type": "default",
-                                                  "innerType": {
-                                                    "def": {
-                                                      "type": "string"
-                                                    },
-                                                    "type": "string",
-                                                    "format": null,
-                                                    "minLength": null,
-                                                    "maxLength": null
-                                                  },
-                                                  "defaultValue": ""
-                                                },
-                                                "type": "default"
-                                              }
-                                            }
-                                          },
-                                          "type": "object"
-                                        }
-                                      },
-                                      "type": "array",
-                                      "element": {
-                                        "def": {
-                                          "type": "object",
-                                          "shape": {
-                                            "metadataStandardId": {
-                                              "def": {
-                                                "type": "default",
-                                                "innerType": {
-                                                  "def": {
-                                                    "type": "string"
-                                                  },
-                                                  "type": "string",
-                                                  "format": null,
-                                                  "minLength": null,
-                                                  "maxLength": null
-                                                },
-                                                "defaultValue": ""
-                                              },
-                                              "type": "default"
-                                            },
-                                            "metadataStandardName": {
-                                              "def": {
-                                                "type": "default",
-                                                "innerType": {
-                                                  "def": {
-                                                    "type": "string"
-                                                  },
-                                                  "type": "string",
-                                                  "format": null,
-                                                  "minLength": null,
-                                                  "maxLength": null
-                                                },
-                                                "defaultValue": ""
-                                              },
-                                              "type": "default"
-                                            }
-                                          }
-                                        },
-                                        "type": "object"
-                                      }
-                                    },
-                                    "defaultValue": []
-                                  },
-                                  "type": "default"
-                                },
-                                "commonStandardId": {
-                                  "def": {
-                                    "type": "optional",
-                                    "innerType": {
-                                      "def": {
-                                        "type": "string"
-                                      },
-                                      "type": "string",
-                                      "format": null,
-                                      "minLength": null,
-                                      "maxLength": null
-                                    }
-                                  },
-                                  "type": "optional"
                                 }
                               }
                             },
@@ -720,106 +712,13 @@
                                 },
                                 "commonStandardId": {
                                   "def": {
-                                    "type": "optional",
-                                    "innerType": {
-                                      "def": {
-                                        "type": "string"
-                                      },
-                                      "type": "string",
-                                      "format": null,
-                                      "minLength": null,
-                                      "maxLength": null
-                                    }
-                                  },
-                                  "type": "optional"
-                                }
-                              }
-                            },
-                            "type": "object"
-                          },
-                          {
-                            "def": {
-                              "type": "object",
-                              "shape": {
-                                "type": {
-                                  "def": {
                                     "type": "literal",
                                     "values": [
-                                      "radioButtons"
+                                      "byte_size"
                                     ]
                                   },
                                   "type": "literal",
                                   "values": {}
-                                },
-                                "meta": {
-                                  "def": {
-                                    "type": "object",
-                                    "shape": {
-                                      "schemaVersion": {
-                                        "def": {
-                                          "type": "default",
-                                          "innerType": {
-                                            "def": {
-                                              "type": "string"
-                                            },
-                                            "type": "string",
-                                            "format": null,
-                                            "minLength": null,
-                                            "maxLength": null
-                                          },
-                                          "defaultValue": "1.0"
-                                        },
-                                        "type": "default"
-                                      }
-                                    }
-                                  },
-                                  "type": "object"
-                                },
-                                "comment": {
-                                  "def": {
-                                    "type": "optional",
-                                    "innerType": {
-                                      "def": {
-                                        "type": "string"
-                                      },
-                                      "type": "string",
-                                      "format": null,
-                                      "minLength": null,
-                                      "maxLength": null
-                                    }
-                                  },
-                                  "type": "optional"
-                                },
-                                "answer": {
-                                  "def": {
-                                    "type": "default",
-                                    "innerType": {
-                                      "def": {
-                                        "type": "string"
-                                      },
-                                      "type": "string",
-                                      "format": null,
-                                      "minLength": null,
-                                      "maxLength": null
-                                    },
-                                    "defaultValue": ""
-                                  },
-                                  "type": "default"
-                                },
-                                "commonStandardId": {
-                                  "def": {
-                                    "type": "optional",
-                                    "innerType": {
-                                      "def": {
-                                        "type": "string"
-                                      },
-                                      "type": "string",
-                                      "format": null,
-                                      "minLength": null,
-                                      "maxLength": null
-                                    }
-                                  },
-                                  "type": "optional"
                                 }
                               }
                             },
@@ -973,18 +872,13 @@
                                 },
                                 "commonStandardId": {
                                   "def": {
-                                    "type": "optional",
-                                    "innerType": {
-                                      "def": {
-                                        "type": "string"
-                                      },
-                                      "type": "string",
-                                      "format": null,
-                                      "minLength": null,
-                                      "maxLength": null
-                                    }
+                                    "type": "literal",
+                                    "values": [
+                                      "host"
+                                    ]
                                   },
-                                  "type": "optional"
+                                  "type": "literal",
+                                  "values": {}
                                 }
                               }
                             },
@@ -998,7 +892,7 @@
                                   "def": {
                                     "type": "literal",
                                     "values": [
-                                      "selectBox"
+                                      "metadataStandardSearch"
                                     ]
                                   },
                                   "type": "literal",
@@ -1048,18 +942,147 @@
                                     "type": "default",
                                     "innerType": {
                                       "def": {
-                                        "type": "string"
+                                        "type": "array",
+                                        "element": {
+                                          "def": {
+                                            "type": "object",
+                                            "shape": {
+                                              "metadataStandardId": {
+                                                "def": {
+                                                  "type": "default",
+                                                  "innerType": {
+                                                    "def": {
+                                                      "type": "string"
+                                                    },
+                                                    "type": "string",
+                                                    "format": null,
+                                                    "minLength": null,
+                                                    "maxLength": null
+                                                  },
+                                                  "defaultValue": ""
+                                                },
+                                                "type": "default"
+                                              },
+                                              "metadataStandardName": {
+                                                "def": {
+                                                  "type": "default",
+                                                  "innerType": {
+                                                    "def": {
+                                                      "type": "string"
+                                                    },
+                                                    "type": "string",
+                                                    "format": null,
+                                                    "minLength": null,
+                                                    "maxLength": null
+                                                  },
+                                                  "defaultValue": ""
+                                                },
+                                                "type": "default"
+                                              }
+                                            }
+                                          },
+                                          "type": "object"
+                                        }
                                       },
-                                      "type": "string",
-                                      "format": null,
-                                      "minLength": null,
-                                      "maxLength": null
+                                      "type": "array",
+                                      "element": {
+                                        "def": {
+                                          "type": "object",
+                                          "shape": {
+                                            "metadataStandardId": {
+                                              "def": {
+                                                "type": "default",
+                                                "innerType": {
+                                                  "def": {
+                                                    "type": "string"
+                                                  },
+                                                  "type": "string",
+                                                  "format": null,
+                                                  "minLength": null,
+                                                  "maxLength": null
+                                                },
+                                                "defaultValue": ""
+                                              },
+                                              "type": "default"
+                                            },
+                                            "metadataStandardName": {
+                                              "def": {
+                                                "type": "default",
+                                                "innerType": {
+                                                  "def": {
+                                                    "type": "string"
+                                                  },
+                                                  "type": "string",
+                                                  "format": null,
+                                                  "minLength": null,
+                                                  "maxLength": null
+                                                },
+                                                "defaultValue": ""
+                                              },
+                                              "type": "default"
+                                            }
+                                          }
+                                        },
+                                        "type": "object"
+                                      }
                                     },
-                                    "defaultValue": ""
+                                    "defaultValue": []
                                   },
                                   "type": "default"
                                 },
                                 "commonStandardId": {
+                                  "def": {
+                                    "type": "literal",
+                                    "values": [
+                                      "metadata"
+                                    ]
+                                  },
+                                  "type": "literal",
+                                  "values": {}
+                                }
+                              }
+                            },
+                            "type": "object"
+                          },
+                          {
+                            "def": {
+                              "type": "object",
+                              "shape": {
+                                "type": {
+                                  "def": {
+                                    "type": "literal",
+                                    "values": [
+                                      "licenseSearch"
+                                    ]
+                                  },
+                                  "type": "literal",
+                                  "values": {}
+                                },
+                                "meta": {
+                                  "def": {
+                                    "type": "object",
+                                    "shape": {
+                                      "schemaVersion": {
+                                        "def": {
+                                          "type": "default",
+                                          "innerType": {
+                                            "def": {
+                                              "type": "string"
+                                            },
+                                            "type": "string",
+                                            "format": null,
+                                            "minLength": null,
+                                            "maxLength": null
+                                          },
+                                          "defaultValue": "1.0"
+                                        },
+                                        "type": "default"
+                                      }
+                                    }
+                                  },
+                                  "type": "object"
+                                },
+                                "comment": {
                                   "def": {
                                     "type": "optional",
                                     "innerType": {
@@ -1073,6 +1096,109 @@
                                     }
                                   },
                                   "type": "optional"
+                                },
+                                "answer": {
+                                  "def": {
+                                    "type": "default",
+                                    "innerType": {
+                                      "def": {
+                                        "type": "array",
+                                        "element": {
+                                          "def": {
+                                            "type": "object",
+                                            "shape": {
+                                              "licenseId": {
+                                                "def": {
+                                                  "type": "default",
+                                                  "innerType": {
+                                                    "def": {
+                                                      "type": "string"
+                                                    },
+                                                    "type": "string",
+                                                    "format": null,
+                                                    "minLength": null,
+                                                    "maxLength": null
+                                                  },
+                                                  "defaultValue": ""
+                                                },
+                                                "type": "default"
+                                              },
+                                              "licenseName": {
+                                                "def": {
+                                                  "type": "default",
+                                                  "innerType": {
+                                                    "def": {
+                                                      "type": "string"
+                                                    },
+                                                    "type": "string",
+                                                    "format": null,
+                                                    "minLength": null,
+                                                    "maxLength": null
+                                                  },
+                                                  "defaultValue": ""
+                                                },
+                                                "type": "default"
+                                              }
+                                            }
+                                          },
+                                          "type": "object"
+                                        }
+                                      },
+                                      "type": "array",
+                                      "element": {
+                                        "def": {
+                                          "type": "object",
+                                          "shape": {
+                                            "licenseId": {
+                                              "def": {
+                                                "type": "default",
+                                                "innerType": {
+                                                  "def": {
+                                                    "type": "string"
+                                                  },
+                                                  "type": "string",
+                                                  "format": null,
+                                                  "minLength": null,
+                                                  "maxLength": null
+                                                },
+                                                "defaultValue": ""
+                                              },
+                                              "type": "default"
+                                            },
+                                            "licenseName": {
+                                              "def": {
+                                                "type": "default",
+                                                "innerType": {
+                                                  "def": {
+                                                    "type": "string"
+                                                  },
+                                                  "type": "string",
+                                                  "format": null,
+                                                  "minLength": null,
+                                                  "maxLength": null
+                                                },
+                                                "defaultValue": ""
+                                              },
+                                              "type": "default"
+                                            }
+                                          }
+                                        },
+                                        "type": "object"
+                                      }
+                                    },
+                                    "defaultValue": []
+                                  },
+                                  "type": "default"
+                                },
+                                "commonStandardId": {
+                                  "def": {
+                                    "type": "literal",
+                                    "values": [
+                                      "license_ref"
+                                    ]
+                                  },
+                                  "type": "literal",
+                                  "values": {}
                                 }
                               }
                             },
@@ -1149,117 +1275,273 @@
                                 },
                                 "commonStandardId": {
                                   "def": {
-                                    "type": "optional",
-                                    "innerType": {
-                                      "def": {
-                                        "type": "string"
-                                      },
-                                      "type": "string",
-                                      "format": null,
-                                      "minLength": null,
-                                      "maxLength": null
-                                    }
-                                  },
-                                  "type": "optional"
-                                }
-                              }
-                            },
-                            "type": "object"
-                          },
-                          {
-                            "def": {
-                              "type": "object",
-                              "shape": {
-                                "type": {
-                                  "def": {
                                     "type": "literal",
                                     "values": [
-                                      "textArea"
+                                      "custom"
                                     ]
                                   },
                                   "type": "literal",
                                   "values": {}
-                                },
-                                "meta": {
-                                  "def": {
-                                    "type": "object",
-                                    "shape": {
-                                      "schemaVersion": {
-                                        "def": {
-                                          "type": "default",
-                                          "innerType": {
-                                            "def": {
-                                              "type": "string"
-                                            },
-                                            "type": "string",
-                                            "format": null,
-                                            "minLength": null,
-                                            "maxLength": null
-                                          },
-                                          "defaultValue": "1.0"
-                                        },
-                                        "type": "default"
-                                      }
-                                    }
-                                  },
-                                  "type": "object"
-                                },
-                                "comment": {
-                                  "def": {
-                                    "type": "optional",
-                                    "innerType": {
-                                      "def": {
-                                        "type": "string"
-                                      },
-                                      "type": "string",
-                                      "format": null,
-                                      "minLength": null,
-                                      "maxLength": null
-                                    }
-                                  },
-                                  "type": "optional"
-                                },
-                                "answer": {
-                                  "def": {
-                                    "type": "default",
-                                    "innerType": {
-                                      "def": {
-                                        "type": "string"
-                                      },
-                                      "type": "string",
-                                      "format": null,
-                                      "minLength": null,
-                                      "maxLength": null
-                                    },
-                                    "defaultValue": ""
-                                  },
-                                  "type": "default"
-                                },
-                                "commonStandardId": {
-                                  "def": {
-                                    "type": "optional",
-                                    "innerType": {
-                                      "def": {
-                                        "type": "string"
-                                      },
-                                      "type": "string",
-                                      "format": null,
-                                      "minLength": null,
-                                      "maxLength": null
-                                    }
-                                  },
-                                  "type": "optional"
                                 }
                               }
                             },
                             "type": "object"
                           }
                         ],
-                        "discriminator": "type",
+                        "discriminator": "commonStandardId",
                         "inclusive": false
                       },
                       "type": "union",
                       "options": [
+                        {
+                          "def": {
+                            "type": "object",
+                            "shape": {
+                              "type": {
+                                "def": {
+                                  "type": "literal",
+                                  "values": [
+                                    "text"
+                                  ]
+                                },
+                                "type": "literal",
+                                "values": {}
+                              },
+                              "meta": {
+                                "def": {
+                                  "type": "object",
+                                  "shape": {
+                                    "schemaVersion": {
+                                      "def": {
+                                        "type": "default",
+                                        "innerType": {
+                                          "def": {
+                                            "type": "string"
+                                          },
+                                          "type": "string",
+                                          "format": null,
+                                          "minLength": null,
+                                          "maxLength": null
+                                        },
+                                        "defaultValue": "1.0"
+                                      },
+                                      "type": "default"
+                                    }
+                                  }
+                                },
+                                "type": "object"
+                              },
+                              "comment": {
+                                "def": {
+                                  "type": "optional",
+                                  "innerType": {
+                                    "def": {
+                                      "type": "string"
+                                    },
+                                    "type": "string",
+                                    "format": null,
+                                    "minLength": null,
+                                    "maxLength": null
+                                  }
+                                },
+                                "type": "optional"
+                              },
+                              "answer": {
+                                "def": {
+                                  "type": "default",
+                                  "innerType": {
+                                    "def": {
+                                      "type": "string"
+                                    },
+                                    "type": "string",
+                                    "format": null,
+                                    "minLength": null,
+                                    "maxLength": null
+                                  },
+                                  "defaultValue": ""
+                                },
+                                "type": "default"
+                              },
+                              "commonStandardId": {
+                                "def": {
+                                  "type": "literal",
+                                  "values": [
+                                    "title"
+                                  ]
+                                },
+                                "type": "literal",
+                                "values": {}
+                              }
+                            }
+                          },
+                          "type": "object"
+                        },
+                        {
+                          "def": {
+                            "type": "object",
+                            "shape": {
+                              "type": {
+                                "def": {
+                                  "type": "literal",
+                                  "values": [
+                                    "textArea"
+                                  ]
+                                },
+                                "type": "literal",
+                                "values": {}
+                              },
+                              "meta": {
+                                "def": {
+                                  "type": "object",
+                                  "shape": {
+                                    "schemaVersion": {
+                                      "def": {
+                                        "type": "default",
+                                        "innerType": {
+                                          "def": {
+                                            "type": "string"
+                                          },
+                                          "type": "string",
+                                          "format": null,
+                                          "minLength": null,
+                                          "maxLength": null
+                                        },
+                                        "defaultValue": "1.0"
+                                      },
+                                      "type": "default"
+                                    }
+                                  }
+                                },
+                                "type": "object"
+                              },
+                              "comment": {
+                                "def": {
+                                  "type": "optional",
+                                  "innerType": {
+                                    "def": {
+                                      "type": "string"
+                                    },
+                                    "type": "string",
+                                    "format": null,
+                                    "minLength": null,
+                                    "maxLength": null
+                                  }
+                                },
+                                "type": "optional"
+                              },
+                              "answer": {
+                                "def": {
+                                  "type": "default",
+                                  "innerType": {
+                                    "def": {
+                                      "type": "string"
+                                    },
+                                    "type": "string",
+                                    "format": null,
+                                    "minLength": null,
+                                    "maxLength": null
+                                  },
+                                  "defaultValue": ""
+                                },
+                                "type": "default"
+                              },
+                              "commonStandardId": {
+                                "def": {
+                                  "type": "literal",
+                                  "values": [
+                                    "description"
+                                  ]
+                                },
+                                "type": "literal",
+                                "values": {}
+                              }
+                            }
+                          },
+                          "type": "object"
+                        },
+                        {
+                          "def": {
+                            "type": "object",
+                            "shape": {
+                              "type": {
+                                "def": {
+                                  "type": "literal",
+                                  "values": [
+                                    "selectBox"
+                                  ]
+                                },
+                                "type": "literal",
+                                "values": {}
+                              },
+                              "meta": {
+                                "def": {
+                                  "type": "object",
+                                  "shape": {
+                                    "schemaVersion": {
+                                      "def": {
+                                        "type": "default",
+                                        "innerType": {
+                                          "def": {
+                                            "type": "string"
+                                          },
+                                          "type": "string",
+                                          "format": null,
+                                          "minLength": null,
+                                          "maxLength": null
+                                        },
+                                        "defaultValue": "1.0"
+                                      },
+                                      "type": "default"
+                                    }
+                                  }
+                                },
+                                "type": "object"
+                              },
+                              "comment": {
+                                "def": {
+                                  "type": "optional",
+                                  "innerType": {
+                                    "def": {
+                                      "type": "string"
+                                    },
+                                    "type": "string",
+                                    "format": null,
+                                    "minLength": null,
+                                    "maxLength": null
+                                  }
+                                },
+                                "type": "optional"
+                              },
+                              "answer": {
+                                "def": {
+                                  "type": "default",
+                                  "innerType": {
+                                    "def": {
+                                      "type": "string"
+                                    },
+                                    "type": "string",
+                                    "format": null,
+                                    "minLength": null,
+                                    "maxLength": null
+                                  },
+                                  "defaultValue": ""
+                                },
+                                "type": "default"
+                              },
+                              "commonStandardId": {
+                                "def": {
+                                  "type": "literal",
+                                  "values": [
+                                    "type"
+                                  ]
+                                },
+                                "type": "literal",
+                                "values": {}
+                              }
+                            }
+                          },
+                          "type": "object"
+                        },
                         {
                           "def": {
                             "type": "object",
@@ -1348,6 +1630,58 @@
                               },
                               "commonStandardId": {
                                 "def": {
+                                  "type": "literal",
+                                  "values": [
+                                    "data_flags"
+                                  ]
+                                },
+                                "type": "literal",
+                                "values": {}
+                              }
+                            }
+                          },
+                          "type": "object"
+                        },
+                        {
+                          "def": {
+                            "type": "object",
+                            "shape": {
+                              "type": {
+                                "def": {
+                                  "type": "literal",
+                                  "values": [
+                                    "radioButtons"
+                                  ]
+                                },
+                                "type": "literal",
+                                "values": {}
+                              },
+                              "meta": {
+                                "def": {
+                                  "type": "object",
+                                  "shape": {
+                                    "schemaVersion": {
+                                      "def": {
+                                        "type": "default",
+                                        "innerType": {
+                                          "def": {
+                                            "type": "string"
+                                          },
+                                          "type": "string",
+                                          "format": null,
+                                          "minLength": null,
+                                          "maxLength": null
+                                        },
+                                        "defaultValue": "1.0"
+                                      },
+                                      "type": "default"
+                                    }
+                                  }
+                                },
+                                "type": "object"
+                              },
+                              "comment": {
+                                "def": {
                                   "type": "optional",
                                   "innerType": {
                                     "def": {
@@ -1360,6 +1694,32 @@
                                   }
                                 },
                                 "type": "optional"
+                              },
+                              "answer": {
+                                "def": {
+                                  "type": "default",
+                                  "innerType": {
+                                    "def": {
+                                      "type": "string"
+                                    },
+                                    "type": "string",
+                                    "format": null,
+                                    "minLength": null,
+                                    "maxLength": null
+                                  },
+                                  "defaultValue": ""
+                                },
+                                "type": "default"
+                              },
+                              "commonStandardId": {
+                                "def": {
+                                  "type": "literal",
+                                  "values": [
+                                    "data_access"
+                                  ]
+                                },
+                                "type": "literal",
+                                "values": {}
                               }
                             }
                           },
@@ -1436,348 +1796,13 @@
                               },
                               "commonStandardId": {
                                 "def": {
-                                  "type": "optional",
-                                  "innerType": {
-                                    "def": {
-                                      "type": "string"
-                                    },
-                                    "type": "string",
-                                    "format": null,
-                                    "minLength": null,
-                                    "maxLength": null
-                                  }
-                                },
-                                "type": "optional"
-                              }
-                            }
-                          },
-                          "type": "object"
-                        },
-                        {
-                          "def": {
-                            "type": "object",
-                            "shape": {
-                              "type": {
-                                "def": {
                                   "type": "literal",
                                   "values": [
-                                    "licenseSearch"
+                                    "issued"
                                   ]
                                 },
                                 "type": "literal",
                                 "values": {}
-                              },
-                              "meta": {
-                                "def": {
-                                  "type": "object",
-                                  "shape": {
-                                    "schemaVersion": {
-                                      "def": {
-                                        "type": "default",
-                                        "innerType": {
-                                          "def": {
-                                            "type": "string"
-                                          },
-                                          "type": "string",
-                                          "format": null,
-                                          "minLength": null,
-                                          "maxLength": null
-                                        },
-                                        "defaultValue": "1.0"
-                                      },
-                                      "type": "default"
-                                    }
-                                  }
-                                },
-                                "type": "object"
-                              },
-                              "comment": {
-                                "def": {
-                                  "type": "optional",
-                                  "innerType": {
-                                    "def": {
-                                      "type": "string"
-                                    },
-                                    "type": "string",
-                                    "format": null,
-                                    "minLength": null,
-                                    "maxLength": null
-                                  }
-                                },
-                                "type": "optional"
-                              },
-                              "answer": {
-                                "def": {
-                                  "type": "default",
-                                  "innerType": {
-                                    "def": {
-                                      "type": "array",
-                                      "element": {
-                                        "def": {
-                                          "type": "object",
-                                          "shape": {
-                                            "licenseId": {
-                                              "def": {
-                                                "type": "default",
-                                                "innerType": {
-                                                  "def": {
-                                                    "type": "string"
-                                                  },
-                                                  "type": "string",
-                                                  "format": null,
-                                                  "minLength": null,
-                                                  "maxLength": null
-                                                },
-                                                "defaultValue": ""
-                                              },
-                                              "type": "default"
-                                            },
-                                            "licenseName": {
-                                              "def": {
-                                                "type": "default",
-                                                "innerType": {
-                                                  "def": {
-                                                    "type": "string"
-                                                  },
-                                                  "type": "string",
-                                                  "format": null,
-                                                  "minLength": null,
-                                                  "maxLength": null
-                                                },
-                                                "defaultValue": ""
-                                              },
-                                              "type": "default"
-                                            }
-                                          }
-                                        },
-                                        "type": "object"
-                                      }
-                                    },
-                                    "type": "array",
-                                    "element": {
-                                      "def": {
-                                        "type": "object",
-                                        "shape": {
-                                          "licenseId": {
-                                            "def": {
-                                              "type": "default",
-                                              "innerType": {
-                                                "def": {
-                                                  "type": "string"
-                                                },
-                                                "type": "string",
-                                                "format": null,
-                                                "minLength": null,
-                                                "maxLength": null
-                                              },
-                                              "defaultValue": ""
-                                            },
-                                            "type": "default"
-                                          },
-                                          "licenseName": {
-                                            "def": {
-                                              "type": "default",
-                                              "innerType": {
-                                                "def": {
-                                                  "type": "string"
-                                                },
-                                                "type": "string",
-                                                "format": null,
-                                                "minLength": null,
-                                                "maxLength": null
-                                              },
-                                              "defaultValue": ""
-                                            },
-                                            "type": "default"
-                                          }
-                                        }
-                                      },
-                                      "type": "object"
-                                    }
-                                  },
-                                  "defaultValue": []
-                                },
-                                "type": "default"
-                              },
-                              "commonStandardId": {
-                                "def": {
-                                  "type": "optional",
-                                  "innerType": {
-                                    "def": {
-                                      "type": "string"
-                                    },
-                                    "type": "string",
-                                    "format": null,
-                                    "minLength": null,
-                                    "maxLength": null
-                                  }
-                                },
-                                "type": "optional"
-                              }
-                            }
-                          },
-                          "type": "object"
-                        },
-                        {
-                          "def": {
-                            "type": "object",
-                            "shape": {
-                              "type": {
-                                "def": {
-                                  "type": "literal",
-                                  "values": [
-                                    "metadataStandardSearch"
-                                  ]
-                                },
-                                "type": "literal",
-                                "values": {}
-                              },
-                              "meta": {
-                                "def": {
-                                  "type": "object",
-                                  "shape": {
-                                    "schemaVersion": {
-                                      "def": {
-                                        "type": "default",
-                                        "innerType": {
-                                          "def": {
-                                            "type": "string"
-                                          },
-                                          "type": "string",
-                                          "format": null,
-                                          "minLength": null,
-                                          "maxLength": null
-                                        },
-                                        "defaultValue": "1.0"
-                                      },
-                                      "type": "default"
-                                    }
-                                  }
-                                },
-                                "type": "object"
-                              },
-                              "comment": {
-                                "def": {
-                                  "type": "optional",
-                                  "innerType": {
-                                    "def": {
-                                      "type": "string"
-                                    },
-                                    "type": "string",
-                                    "format": null,
-                                    "minLength": null,
-                                    "maxLength": null
-                                  }
-                                },
-                                "type": "optional"
-                              },
-                              "answer": {
-                                "def": {
-                                  "type": "default",
-                                  "innerType": {
-                                    "def": {
-                                      "type": "array",
-                                      "element": {
-                                        "def": {
-                                          "type": "object",
-                                          "shape": {
-                                            "metadataStandardId": {
-                                              "def": {
-                                                "type": "default",
-                                                "innerType": {
-                                                  "def": {
-                                                    "type": "string"
-                                                  },
-                                                  "type": "string",
-                                                  "format": null,
-                                                  "minLength": null,
-                                                  "maxLength": null
-                                                },
-                                                "defaultValue": ""
-                                              },
-                                              "type": "default"
-                                            },
-                                            "metadataStandardName": {
-                                              "def": {
-                                                "type": "default",
-                                                "innerType": {
-                                                  "def": {
-                                                    "type": "string"
-                                                  },
-                                                  "type": "string",
-                                                  "format": null,
-                                                  "minLength": null,
-                                                  "maxLength": null
-                                                },
-                                                "defaultValue": ""
-                                              },
-                                              "type": "default"
-                                            }
-                                          }
-                                        },
-                                        "type": "object"
-                                      }
-                                    },
-                                    "type": "array",
-                                    "element": {
-                                      "def": {
-                                        "type": "object",
-                                        "shape": {
-                                          "metadataStandardId": {
-                                            "def": {
-                                              "type": "default",
-                                              "innerType": {
-                                                "def": {
-                                                  "type": "string"
-                                                },
-                                                "type": "string",
-                                                "format": null,
-                                                "minLength": null,
-                                                "maxLength": null
-                                              },
-                                              "defaultValue": ""
-                                            },
-                                            "type": "default"
-                                          },
-                                          "metadataStandardName": {
-                                            "def": {
-                                              "type": "default",
-                                              "innerType": {
-                                                "def": {
-                                                  "type": "string"
-                                                },
-                                                "type": "string",
-                                                "format": null,
-                                                "minLength": null,
-                                                "maxLength": null
-                                              },
-                                              "defaultValue": ""
-                                            },
-                                            "type": "default"
-                                          }
-                                        }
-                                      },
-                                      "type": "object"
-                                    }
-                                  },
-                                  "defaultValue": []
-                                },
-                                "type": "default"
-                              },
-                              "commonStandardId": {
-                                "def": {
-                                  "type": "optional",
-                                  "innerType": {
-                                    "def": {
-                                      "type": "string"
-                                    },
-                                    "type": "string",
-                                    "format": null,
-                                    "minLength": null,
-                                    "maxLength": null
-                                  }
-                                },
-                                "type": "optional"
                               }
                             }
                           },
@@ -1881,106 +1906,13 @@
                               },
                               "commonStandardId": {
                                 "def": {
-                                  "type": "optional",
-                                  "innerType": {
-                                    "def": {
-                                      "type": "string"
-                                    },
-                                    "type": "string",
-                                    "format": null,
-                                    "minLength": null,
-                                    "maxLength": null
-                                  }
-                                },
-                                "type": "optional"
-                              }
-                            }
-                          },
-                          "type": "object"
-                        },
-                        {
-                          "def": {
-                            "type": "object",
-                            "shape": {
-                              "type": {
-                                "def": {
                                   "type": "literal",
                                   "values": [
-                                    "radioButtons"
+                                    "byte_size"
                                   ]
                                 },
                                 "type": "literal",
                                 "values": {}
-                              },
-                              "meta": {
-                                "def": {
-                                  "type": "object",
-                                  "shape": {
-                                    "schemaVersion": {
-                                      "def": {
-                                        "type": "default",
-                                        "innerType": {
-                                          "def": {
-                                            "type": "string"
-                                          },
-                                          "type": "string",
-                                          "format": null,
-                                          "minLength": null,
-                                          "maxLength": null
-                                        },
-                                        "defaultValue": "1.0"
-                                      },
-                                      "type": "default"
-                                    }
-                                  }
-                                },
-                                "type": "object"
-                              },
-                              "comment": {
-                                "def": {
-                                  "type": "optional",
-                                  "innerType": {
-                                    "def": {
-                                      "type": "string"
-                                    },
-                                    "type": "string",
-                                    "format": null,
-                                    "minLength": null,
-                                    "maxLength": null
-                                  }
-                                },
-                                "type": "optional"
-                              },
-                              "answer": {
-                                "def": {
-                                  "type": "default",
-                                  "innerType": {
-                                    "def": {
-                                      "type": "string"
-                                    },
-                                    "type": "string",
-                                    "format": null,
-                                    "minLength": null,
-                                    "maxLength": null
-                                  },
-                                  "defaultValue": ""
-                                },
-                                "type": "default"
-                              },
-                              "commonStandardId": {
-                                "def": {
-                                  "type": "optional",
-                                  "innerType": {
-                                    "def": {
-                                      "type": "string"
-                                    },
-                                    "type": "string",
-                                    "format": null,
-                                    "minLength": null,
-                                    "maxLength": null
-                                  }
-                                },
-                                "type": "optional"
                               }
                             }
                           },
@@ -2134,18 +2066,13 @@
                               },
                               "commonStandardId": {
                                 "def": {
-                                  "type": "optional",
-                                  "innerType": {
-                                    "def": {
-                                      "type": "string"
-                                    },
-                                    "type": "string",
-                                    "format": null,
-                                    "minLength": null,
-                                    "maxLength": null
-                                  }
+                                  "type": "literal",
+                                  "values": [
+                                    "host"
+                                  ]
                                 },
-                                "type": "optional"
+                                "type": "literal",
+                                "values": {}
                               }
                             }
                           },
@@ -2159,7 +2086,7 @@
                                 "def": {
                                   "type": "literal",
                                   "values": [
-                                    "selectBox"
+                                    "metadataStandardSearch"
                                   ]
                                 },
                                 "type": "literal",
@@ -2209,18 +2136,147 @@
                                   "type": "default",
                                   "innerType": {
                                     "def": {
-                                      "type": "string"
+                                      "type": "array",
+                                      "element": {
+                                        "def": {
+                                          "type": "object",
+                                          "shape": {
+                                            "metadataStandardId": {
+                                              "def": {
+                                                "type": "default",
+                                                "innerType": {
+                                                  "def": {
+                                                    "type": "string"
+                                                  },
+                                                  "type": "string",
+                                                  "format": null,
+                                                  "minLength": null,
+                                                  "maxLength": null
+                                                },
+                                                "defaultValue": ""
+                                              },
+                                              "type": "default"
+                                            },
+                                            "metadataStandardName": {
+                                              "def": {
+                                                "type": "default",
+                                                "innerType": {
+                                                  "def": {
+                                                    "type": "string"
+                                                  },
+                                                  "type": "string",
+                                                  "format": null,
+                                                  "minLength": null,
+                                                  "maxLength": null
+                                                },
+                                                "defaultValue": ""
+                                              },
+                                              "type": "default"
+                                            }
+                                          }
+                                        },
+                                        "type": "object"
+                                      }
                                     },
-                                    "type": "string",
-                                    "format": null,
-                                    "minLength": null,
-                                    "maxLength": null
+                                    "type": "array",
+                                    "element": {
+                                      "def": {
+                                        "type": "object",
+                                        "shape": {
+                                          "metadataStandardId": {
+                                            "def": {
+                                              "type": "default",
+                                              "innerType": {
+                                                "def": {
+                                                  "type": "string"
+                                                },
+                                                "type": "string",
+                                                "format": null,
+                                                "minLength": null,
+                                                "maxLength": null
+                                              },
+                                              "defaultValue": ""
+                                            },
+                                            "type": "default"
+                                          },
+                                          "metadataStandardName": {
+                                            "def": {
+                                              "type": "default",
+                                              "innerType": {
+                                                "def": {
+                                                  "type": "string"
+                                                },
+                                                "type": "string",
+                                                "format": null,
+                                                "minLength": null,
+                                                "maxLength": null
+                                              },
+                                              "defaultValue": ""
+                                            },
+                                            "type": "default"
+                                          }
+                                        }
+                                      },
+                                      "type": "object"
+                                    }
                                   },
-                                  "defaultValue": ""
+                                  "defaultValue": []
                                 },
                                 "type": "default"
                               },
                               "commonStandardId": {
+                                "def": {
+                                  "type": "literal",
+                                  "values": [
+                                    "metadata"
+                                  ]
+                                },
+                                "type": "literal",
+                                "values": {}
+                              }
+                            }
+                          },
+                          "type": "object"
+                        },
+                        {
+                          "def": {
+                            "type": "object",
+                            "shape": {
+                              "type": {
+                                "def": {
+                                  "type": "literal",
+                                  "values": [
+                                    "licenseSearch"
+                                  ]
+                                },
+                                "type": "literal",
+                                "values": {}
+                              },
+                              "meta": {
+                                "def": {
+                                  "type": "object",
+                                  "shape": {
+                                    "schemaVersion": {
+                                      "def": {
+                                        "type": "default",
+                                        "innerType": {
+                                          "def": {
+                                            "type": "string"
+                                          },
+                                          "type": "string",
+                                          "format": null,
+                                          "minLength": null,
+                                          "maxLength": null
+                                        },
+                                        "defaultValue": "1.0"
+                                      },
+                                      "type": "default"
+                                    }
+                                  }
+                                },
+                                "type": "object"
+                              },
+                              "comment": {
                                 "def": {
                                   "type": "optional",
                                   "innerType": {
@@ -2234,6 +2290,109 @@
                                   }
                                 },
                                 "type": "optional"
+                              },
+                              "answer": {
+                                "def": {
+                                  "type": "default",
+                                  "innerType": {
+                                    "def": {
+                                      "type": "array",
+                                      "element": {
+                                        "def": {
+                                          "type": "object",
+                                          "shape": {
+                                            "licenseId": {
+                                              "def": {
+                                                "type": "default",
+                                                "innerType": {
+                                                  "def": {
+                                                    "type": "string"
+                                                  },
+                                                  "type": "string",
+                                                  "format": null,
+                                                  "minLength": null,
+                                                  "maxLength": null
+                                                },
+                                                "defaultValue": ""
+                                              },
+                                              "type": "default"
+                                            },
+                                            "licenseName": {
+                                              "def": {
+                                                "type": "default",
+                                                "innerType": {
+                                                  "def": {
+                                                    "type": "string"
+                                                  },
+                                                  "type": "string",
+                                                  "format": null,
+                                                  "minLength": null,
+                                                  "maxLength": null
+                                                },
+                                                "defaultValue": ""
+                                              },
+                                              "type": "default"
+                                            }
+                                          }
+                                        },
+                                        "type": "object"
+                                      }
+                                    },
+                                    "type": "array",
+                                    "element": {
+                                      "def": {
+                                        "type": "object",
+                                        "shape": {
+                                          "licenseId": {
+                                            "def": {
+                                              "type": "default",
+                                              "innerType": {
+                                                "def": {
+                                                  "type": "string"
+                                                },
+                                                "type": "string",
+                                                "format": null,
+                                                "minLength": null,
+                                                "maxLength": null
+                                              },
+                                              "defaultValue": ""
+                                            },
+                                            "type": "default"
+                                          },
+                                          "licenseName": {
+                                            "def": {
+                                              "type": "default",
+                                              "innerType": {
+                                                "def": {
+                                                  "type": "string"
+                                                },
+                                                "type": "string",
+                                                "format": null,
+                                                "minLength": null,
+                                                "maxLength": null
+                                              },
+                                              "defaultValue": ""
+                                            },
+                                            "type": "default"
+                                          }
+                                        }
+                                      },
+                                      "type": "object"
+                                    }
+                                  },
+                                  "defaultValue": []
+                                },
+                                "type": "default"
+                              },
+                              "commonStandardId": {
+                                "def": {
+                                  "type": "literal",
+                                  "values": [
+                                    "license_ref"
+                                  ]
+                                },
+                                "type": "literal",
+                                "values": {}
                               }
                             }
                           },
@@ -2310,106 +2469,13 @@
                               },
                               "commonStandardId": {
                                 "def": {
-                                  "type": "optional",
-                                  "innerType": {
-                                    "def": {
-                                      "type": "string"
-                                    },
-                                    "type": "string",
-                                    "format": null,
-                                    "minLength": null,
-                                    "maxLength": null
-                                  }
-                                },
-                                "type": "optional"
-                              }
-                            }
-                          },
-                          "type": "object"
-                        },
-                        {
-                          "def": {
-                            "type": "object",
-                            "shape": {
-                              "type": {
-                                "def": {
                                   "type": "literal",
                                   "values": [
-                                    "textArea"
+                                    "custom"
                                   ]
                                 },
                                 "type": "literal",
                                 "values": {}
-                              },
-                              "meta": {
-                                "def": {
-                                  "type": "object",
-                                  "shape": {
-                                    "schemaVersion": {
-                                      "def": {
-                                        "type": "default",
-                                        "innerType": {
-                                          "def": {
-                                            "type": "string"
-                                          },
-                                          "type": "string",
-                                          "format": null,
-                                          "minLength": null,
-                                          "maxLength": null
-                                        },
-                                        "defaultValue": "1.0"
-                                      },
-                                      "type": "default"
-                                    }
-                                  }
-                                },
-                                "type": "object"
-                              },
-                              "comment": {
-                                "def": {
-                                  "type": "optional",
-                                  "innerType": {
-                                    "def": {
-                                      "type": "string"
-                                    },
-                                    "type": "string",
-                                    "format": null,
-                                    "minLength": null,
-                                    "maxLength": null
-                                  }
-                                },
-                                "type": "optional"
-                              },
-                              "answer": {
-                                "def": {
-                                  "type": "default",
-                                  "innerType": {
-                                    "def": {
-                                      "type": "string"
-                                    },
-                                    "type": "string",
-                                    "format": null,
-                                    "minLength": null,
-                                    "maxLength": null
-                                  },
-                                  "defaultValue": ""
-                                },
-                                "type": "default"
-                              },
-                              "commonStandardId": {
-                                "def": {
-                                  "type": "optional",
-                                  "innerType": {
-                                    "def": {
-                                      "type": "string"
-                                    },
-                                    "type": "string",
-                                    "format": null,
-                                    "minLength": null,
-                                    "maxLength": null
-                                  }
-                                },
-                                "type": "optional"
                               }
                             }
                           },
@@ -2431,6 +2497,255 @@
                                 "def": {
                                   "type": "literal",
                                   "values": [
+                                    "text"
+                                  ]
+                                },
+                                "type": "literal",
+                                "values": {}
+                              },
+                              "meta": {
+                                "def": {
+                                  "type": "object",
+                                  "shape": {
+                                    "schemaVersion": {
+                                      "def": {
+                                        "type": "default",
+                                        "innerType": {
+                                          "def": {
+                                            "type": "string"
+                                          },
+                                          "type": "string",
+                                          "format": null,
+                                          "minLength": null,
+                                          "maxLength": null
+                                        },
+                                        "defaultValue": "1.0"
+                                      },
+                                      "type": "default"
+                                    }
+                                  }
+                                },
+                                "type": "object"
+                              },
+                              "comment": {
+                                "def": {
+                                  "type": "optional",
+                                  "innerType": {
+                                    "def": {
+                                      "type": "string"
+                                    },
+                                    "type": "string",
+                                    "format": null,
+                                    "minLength": null,
+                                    "maxLength": null
+                                  }
+                                },
+                                "type": "optional"
+                              },
+                              "answer": {
+                                "def": {
+                                  "type": "default",
+                                  "innerType": {
+                                    "def": {
+                                      "type": "string"
+                                    },
+                                    "type": "string",
+                                    "format": null,
+                                    "minLength": null,
+                                    "maxLength": null
+                                  },
+                                  "defaultValue": ""
+                                },
+                                "type": "default"
+                              },
+                              "commonStandardId": {
+                                "def": {
+                                  "type": "literal",
+                                  "values": [
+                                    "title"
+                                  ]
+                                },
+                                "type": "literal",
+                                "values": {}
+                              }
+                            }
+                          },
+                          "type": "object"
+                        },
+                        {
+                          "def": {
+                            "type": "object",
+                            "shape": {
+                              "type": {
+                                "def": {
+                                  "type": "literal",
+                                  "values": [
+                                    "textArea"
+                                  ]
+                                },
+                                "type": "literal",
+                                "values": {}
+                              },
+                              "meta": {
+                                "def": {
+                                  "type": "object",
+                                  "shape": {
+                                    "schemaVersion": {
+                                      "def": {
+                                        "type": "default",
+                                        "innerType": {
+                                          "def": {
+                                            "type": "string"
+                                          },
+                                          "type": "string",
+                                          "format": null,
+                                          "minLength": null,
+                                          "maxLength": null
+                                        },
+                                        "defaultValue": "1.0"
+                                      },
+                                      "type": "default"
+                                    }
+                                  }
+                                },
+                                "type": "object"
+                              },
+                              "comment": {
+                                "def": {
+                                  "type": "optional",
+                                  "innerType": {
+                                    "def": {
+                                      "type": "string"
+                                    },
+                                    "type": "string",
+                                    "format": null,
+                                    "minLength": null,
+                                    "maxLength": null
+                                  }
+                                },
+                                "type": "optional"
+                              },
+                              "answer": {
+                                "def": {
+                                  "type": "default",
+                                  "innerType": {
+                                    "def": {
+                                      "type": "string"
+                                    },
+                                    "type": "string",
+                                    "format": null,
+                                    "minLength": null,
+                                    "maxLength": null
+                                  },
+                                  "defaultValue": ""
+                                },
+                                "type": "default"
+                              },
+                              "commonStandardId": {
+                                "def": {
+                                  "type": "literal",
+                                  "values": [
+                                    "description"
+                                  ]
+                                },
+                                "type": "literal",
+                                "values": {}
+                              }
+                            }
+                          },
+                          "type": "object"
+                        },
+                        {
+                          "def": {
+                            "type": "object",
+                            "shape": {
+                              "type": {
+                                "def": {
+                                  "type": "literal",
+                                  "values": [
+                                    "selectBox"
+                                  ]
+                                },
+                                "type": "literal",
+                                "values": {}
+                              },
+                              "meta": {
+                                "def": {
+                                  "type": "object",
+                                  "shape": {
+                                    "schemaVersion": {
+                                      "def": {
+                                        "type": "default",
+                                        "innerType": {
+                                          "def": {
+                                            "type": "string"
+                                          },
+                                          "type": "string",
+                                          "format": null,
+                                          "minLength": null,
+                                          "maxLength": null
+                                        },
+                                        "defaultValue": "1.0"
+                                      },
+                                      "type": "default"
+                                    }
+                                  }
+                                },
+                                "type": "object"
+                              },
+                              "comment": {
+                                "def": {
+                                  "type": "optional",
+                                  "innerType": {
+                                    "def": {
+                                      "type": "string"
+                                    },
+                                    "type": "string",
+                                    "format": null,
+                                    "minLength": null,
+                                    "maxLength": null
+                                  }
+                                },
+                                "type": "optional"
+                              },
+                              "answer": {
+                                "def": {
+                                  "type": "default",
+                                  "innerType": {
+                                    "def": {
+                                      "type": "string"
+                                    },
+                                    "type": "string",
+                                    "format": null,
+                                    "minLength": null,
+                                    "maxLength": null
+                                  },
+                                  "defaultValue": ""
+                                },
+                                "type": "default"
+                              },
+                              "commonStandardId": {
+                                "def": {
+                                  "type": "literal",
+                                  "values": [
+                                    "type"
+                                  ]
+                                },
+                                "type": "literal",
+                                "values": {}
+                              }
+                            }
+                          },
+                          "type": "object"
+                        },
+                        {
+                          "def": {
+                            "type": "object",
+                            "shape": {
+                              "type": {
+                                "def": {
+                                  "type": "literal",
+                                  "values": [
                                     "checkBoxes"
                                   ]
                                 },
@@ -2511,6 +2826,58 @@
                               },
                               "commonStandardId": {
                                 "def": {
+                                  "type": "literal",
+                                  "values": [
+                                    "data_flags"
+                                  ]
+                                },
+                                "type": "literal",
+                                "values": {}
+                              }
+                            }
+                          },
+                          "type": "object"
+                        },
+                        {
+                          "def": {
+                            "type": "object",
+                            "shape": {
+                              "type": {
+                                "def": {
+                                  "type": "literal",
+                                  "values": [
+                                    "radioButtons"
+                                  ]
+                                },
+                                "type": "literal",
+                                "values": {}
+                              },
+                              "meta": {
+                                "def": {
+                                  "type": "object",
+                                  "shape": {
+                                    "schemaVersion": {
+                                      "def": {
+                                        "type": "default",
+                                        "innerType": {
+                                          "def": {
+                                            "type": "string"
+                                          },
+                                          "type": "string",
+                                          "format": null,
+                                          "minLength": null,
+                                          "maxLength": null
+                                        },
+                                        "defaultValue": "1.0"
+                                      },
+                                      "type": "default"
+                                    }
+                                  }
+                                },
+                                "type": "object"
+                              },
+                              "comment": {
+                                "def": {
                                   "type": "optional",
                                   "innerType": {
                                     "def": {
@@ -2523,6 +2890,32 @@
                                   }
                                 },
                                 "type": "optional"
+                              },
+                              "answer": {
+                                "def": {
+                                  "type": "default",
+                                  "innerType": {
+                                    "def": {
+                                      "type": "string"
+                                    },
+                                    "type": "string",
+                                    "format": null,
+                                    "minLength": null,
+                                    "maxLength": null
+                                  },
+                                  "defaultValue": ""
+                                },
+                                "type": "default"
+                              },
+                              "commonStandardId": {
+                                "def": {
+                                  "type": "literal",
+                                  "values": [
+                                    "data_access"
+                                  ]
+                                },
+                                "type": "literal",
+                                "values": {}
                               }
                             }
                           },
@@ -2599,348 +2992,13 @@
                               },
                               "commonStandardId": {
                                 "def": {
-                                  "type": "optional",
-                                  "innerType": {
-                                    "def": {
-                                      "type": "string"
-                                    },
-                                    "type": "string",
-                                    "format": null,
-                                    "minLength": null,
-                                    "maxLength": null
-                                  }
-                                },
-                                "type": "optional"
-                              }
-                            }
-                          },
-                          "type": "object"
-                        },
-                        {
-                          "def": {
-                            "type": "object",
-                            "shape": {
-                              "type": {
-                                "def": {
                                   "type": "literal",
                                   "values": [
-                                    "licenseSearch"
+                                    "issued"
                                   ]
                                 },
                                 "type": "literal",
                                 "values": {}
-                              },
-                              "meta": {
-                                "def": {
-                                  "type": "object",
-                                  "shape": {
-                                    "schemaVersion": {
-                                      "def": {
-                                        "type": "default",
-                                        "innerType": {
-                                          "def": {
-                                            "type": "string"
-                                          },
-                                          "type": "string",
-                                          "format": null,
-                                          "minLength": null,
-                                          "maxLength": null
-                                        },
-                                        "defaultValue": "1.0"
-                                      },
-                                      "type": "default"
-                                    }
-                                  }
-                                },
-                                "type": "object"
-                              },
-                              "comment": {
-                                "def": {
-                                  "type": "optional",
-                                  "innerType": {
-                                    "def": {
-                                      "type": "string"
-                                    },
-                                    "type": "string",
-                                    "format": null,
-                                    "minLength": null,
-                                    "maxLength": null
-                                  }
-                                },
-                                "type": "optional"
-                              },
-                              "answer": {
-                                "def": {
-                                  "type": "default",
-                                  "innerType": {
-                                    "def": {
-                                      "type": "array",
-                                      "element": {
-                                        "def": {
-                                          "type": "object",
-                                          "shape": {
-                                            "licenseId": {
-                                              "def": {
-                                                "type": "default",
-                                                "innerType": {
-                                                  "def": {
-                                                    "type": "string"
-                                                  },
-                                                  "type": "string",
-                                                  "format": null,
-                                                  "minLength": null,
-                                                  "maxLength": null
-                                                },
-                                                "defaultValue": ""
-                                              },
-                                              "type": "default"
-                                            },
-                                            "licenseName": {
-                                              "def": {
-                                                "type": "default",
-                                                "innerType": {
-                                                  "def": {
-                                                    "type": "string"
-                                                  },
-                                                  "type": "string",
-                                                  "format": null,
-                                                  "minLength": null,
-                                                  "maxLength": null
-                                                },
-                                                "defaultValue": ""
-                                              },
-                                              "type": "default"
-                                            }
-                                          }
-                                        },
-                                        "type": "object"
-                                      }
-                                    },
-                                    "type": "array",
-                                    "element": {
-                                      "def": {
-                                        "type": "object",
-                                        "shape": {
-                                          "licenseId": {
-                                            "def": {
-                                              "type": "default",
-                                              "innerType": {
-                                                "def": {
-                                                  "type": "string"
-                                                },
-                                                "type": "string",
-                                                "format": null,
-                                                "minLength": null,
-                                                "maxLength": null
-                                              },
-                                              "defaultValue": ""
-                                            },
-                                            "type": "default"
-                                          },
-                                          "licenseName": {
-                                            "def": {
-                                              "type": "default",
-                                              "innerType": {
-                                                "def": {
-                                                  "type": "string"
-                                                },
-                                                "type": "string",
-                                                "format": null,
-                                                "minLength": null,
-                                                "maxLength": null
-                                              },
-                                              "defaultValue": ""
-                                            },
-                                            "type": "default"
-                                          }
-                                        }
-                                      },
-                                      "type": "object"
-                                    }
-                                  },
-                                  "defaultValue": []
-                                },
-                                "type": "default"
-                              },
-                              "commonStandardId": {
-                                "def": {
-                                  "type": "optional",
-                                  "innerType": {
-                                    "def": {
-                                      "type": "string"
-                                    },
-                                    "type": "string",
-                                    "format": null,
-                                    "minLength": null,
-                                    "maxLength": null
-                                  }
-                                },
-                                "type": "optional"
-                              }
-                            }
-                          },
-                          "type": "object"
-                        },
-                        {
-                          "def": {
-                            "type": "object",
-                            "shape": {
-                              "type": {
-                                "def": {
-                                  "type": "literal",
-                                  "values": [
-                                    "metadataStandardSearch"
-                                  ]
-                                },
-                                "type": "literal",
-                                "values": {}
-                              },
-                              "meta": {
-                                "def": {
-                                  "type": "object",
-                                  "shape": {
-                                    "schemaVersion": {
-                                      "def": {
-                                        "type": "default",
-                                        "innerType": {
-                                          "def": {
-                                            "type": "string"
-                                          },
-                                          "type": "string",
-                                          "format": null,
-                                          "minLength": null,
-                                          "maxLength": null
-                                        },
-                                        "defaultValue": "1.0"
-                                      },
-                                      "type": "default"
-                                    }
-                                  }
-                                },
-                                "type": "object"
-                              },
-                              "comment": {
-                                "def": {
-                                  "type": "optional",
-                                  "innerType": {
-                                    "def": {
-                                      "type": "string"
-                                    },
-                                    "type": "string",
-                                    "format": null,
-                                    "minLength": null,
-                                    "maxLength": null
-                                  }
-                                },
-                                "type": "optional"
-                              },
-                              "answer": {
-                                "def": {
-                                  "type": "default",
-                                  "innerType": {
-                                    "def": {
-                                      "type": "array",
-                                      "element": {
-                                        "def": {
-                                          "type": "object",
-                                          "shape": {
-                                            "metadataStandardId": {
-                                              "def": {
-                                                "type": "default",
-                                                "innerType": {
-                                                  "def": {
-                                                    "type": "string"
-                                                  },
-                                                  "type": "string",
-                                                  "format": null,
-                                                  "minLength": null,
-                                                  "maxLength": null
-                                                },
-                                                "defaultValue": ""
-                                              },
-                                              "type": "default"
-                                            },
-                                            "metadataStandardName": {
-                                              "def": {
-                                                "type": "default",
-                                                "innerType": {
-                                                  "def": {
-                                                    "type": "string"
-                                                  },
-                                                  "type": "string",
-                                                  "format": null,
-                                                  "minLength": null,
-                                                  "maxLength": null
-                                                },
-                                                "defaultValue": ""
-                                              },
-                                              "type": "default"
-                                            }
-                                          }
-                                        },
-                                        "type": "object"
-                                      }
-                                    },
-                                    "type": "array",
-                                    "element": {
-                                      "def": {
-                                        "type": "object",
-                                        "shape": {
-                                          "metadataStandardId": {
-                                            "def": {
-                                              "type": "default",
-                                              "innerType": {
-                                                "def": {
-                                                  "type": "string"
-                                                },
-                                                "type": "string",
-                                                "format": null,
-                                                "minLength": null,
-                                                "maxLength": null
-                                              },
-                                              "defaultValue": ""
-                                            },
-                                            "type": "default"
-                                          },
-                                          "metadataStandardName": {
-                                            "def": {
-                                              "type": "default",
-                                              "innerType": {
-                                                "def": {
-                                                  "type": "string"
-                                                },
-                                                "type": "string",
-                                                "format": null,
-                                                "minLength": null,
-                                                "maxLength": null
-                                              },
-                                              "defaultValue": ""
-                                            },
-                                            "type": "default"
-                                          }
-                                        }
-                                      },
-                                      "type": "object"
-                                    }
-                                  },
-                                  "defaultValue": []
-                                },
-                                "type": "default"
-                              },
-                              "commonStandardId": {
-                                "def": {
-                                  "type": "optional",
-                                  "innerType": {
-                                    "def": {
-                                      "type": "string"
-                                    },
-                                    "type": "string",
-                                    "format": null,
-                                    "minLength": null,
-                                    "maxLength": null
-                                  }
-                                },
-                                "type": "optional"
                               }
                             }
                           },
@@ -3044,106 +3102,13 @@
                               },
                               "commonStandardId": {
                                 "def": {
-                                  "type": "optional",
-                                  "innerType": {
-                                    "def": {
-                                      "type": "string"
-                                    },
-                                    "type": "string",
-                                    "format": null,
-                                    "minLength": null,
-                                    "maxLength": null
-                                  }
-                                },
-                                "type": "optional"
-                              }
-                            }
-                          },
-                          "type": "object"
-                        },
-                        {
-                          "def": {
-                            "type": "object",
-                            "shape": {
-                              "type": {
-                                "def": {
                                   "type": "literal",
                                   "values": [
-                                    "radioButtons"
+                                    "byte_size"
                                   ]
                                 },
                                 "type": "literal",
                                 "values": {}
-                              },
-                              "meta": {
-                                "def": {
-                                  "type": "object",
-                                  "shape": {
-                                    "schemaVersion": {
-                                      "def": {
-                                        "type": "default",
-                                        "innerType": {
-                                          "def": {
-                                            "type": "string"
-                                          },
-                                          "type": "string",
-                                          "format": null,
-                                          "minLength": null,
-                                          "maxLength": null
-                                        },
-                                        "defaultValue": "1.0"
-                                      },
-                                      "type": "default"
-                                    }
-                                  }
-                                },
-                                "type": "object"
-                              },
-                              "comment": {
-                                "def": {
-                                  "type": "optional",
-                                  "innerType": {
-                                    "def": {
-                                      "type": "string"
-                                    },
-                                    "type": "string",
-                                    "format": null,
-                                    "minLength": null,
-                                    "maxLength": null
-                                  }
-                                },
-                                "type": "optional"
-                              },
-                              "answer": {
-                                "def": {
-                                  "type": "default",
-                                  "innerType": {
-                                    "def": {
-                                      "type": "string"
-                                    },
-                                    "type": "string",
-                                    "format": null,
-                                    "minLength": null,
-                                    "maxLength": null
-                                  },
-                                  "defaultValue": ""
-                                },
-                                "type": "default"
-                              },
-                              "commonStandardId": {
-                                "def": {
-                                  "type": "optional",
-                                  "innerType": {
-                                    "def": {
-                                      "type": "string"
-                                    },
-                                    "type": "string",
-                                    "format": null,
-                                    "minLength": null,
-                                    "maxLength": null
-                                  }
-                                },
-                                "type": "optional"
                               }
                             }
                           },
@@ -3297,18 +3262,13 @@
                               },
                               "commonStandardId": {
                                 "def": {
-                                  "type": "optional",
-                                  "innerType": {
-                                    "def": {
-                                      "type": "string"
-                                    },
-                                    "type": "string",
-                                    "format": null,
-                                    "minLength": null,
-                                    "maxLength": null
-                                  }
+                                  "type": "literal",
+                                  "values": [
+                                    "host"
+                                  ]
                                 },
-                                "type": "optional"
+                                "type": "literal",
+                                "values": {}
                               }
                             }
                           },
@@ -3322,7 +3282,7 @@
                                 "def": {
                                   "type": "literal",
                                   "values": [
-                                    "selectBox"
+                                    "metadataStandardSearch"
                                   ]
                                 },
                                 "type": "literal",
@@ -3372,18 +3332,147 @@
                                   "type": "default",
                                   "innerType": {
                                     "def": {
-                                      "type": "string"
+                                      "type": "array",
+                                      "element": {
+                                        "def": {
+                                          "type": "object",
+                                          "shape": {
+                                            "metadataStandardId": {
+                                              "def": {
+                                                "type": "default",
+                                                "innerType": {
+                                                  "def": {
+                                                    "type": "string"
+                                                  },
+                                                  "type": "string",
+                                                  "format": null,
+                                                  "minLength": null,
+                                                  "maxLength": null
+                                                },
+                                                "defaultValue": ""
+                                              },
+                                              "type": "default"
+                                            },
+                                            "metadataStandardName": {
+                                              "def": {
+                                                "type": "default",
+                                                "innerType": {
+                                                  "def": {
+                                                    "type": "string"
+                                                  },
+                                                  "type": "string",
+                                                  "format": null,
+                                                  "minLength": null,
+                                                  "maxLength": null
+                                                },
+                                                "defaultValue": ""
+                                              },
+                                              "type": "default"
+                                            }
+                                          }
+                                        },
+                                        "type": "object"
+                                      }
                                     },
-                                    "type": "string",
-                                    "format": null,
-                                    "minLength": null,
-                                    "maxLength": null
+                                    "type": "array",
+                                    "element": {
+                                      "def": {
+                                        "type": "object",
+                                        "shape": {
+                                          "metadataStandardId": {
+                                            "def": {
+                                              "type": "default",
+                                              "innerType": {
+                                                "def": {
+                                                  "type": "string"
+                                                },
+                                                "type": "string",
+                                                "format": null,
+                                                "minLength": null,
+                                                "maxLength": null
+                                              },
+                                              "defaultValue": ""
+                                            },
+                                            "type": "default"
+                                          },
+                                          "metadataStandardName": {
+                                            "def": {
+                                              "type": "default",
+                                              "innerType": {
+                                                "def": {
+                                                  "type": "string"
+                                                },
+                                                "type": "string",
+                                                "format": null,
+                                                "minLength": null,
+                                                "maxLength": null
+                                              },
+                                              "defaultValue": ""
+                                            },
+                                            "type": "default"
+                                          }
+                                        }
+                                      },
+                                      "type": "object"
+                                    }
                                   },
-                                  "defaultValue": ""
+                                  "defaultValue": []
                                 },
                                 "type": "default"
                               },
                               "commonStandardId": {
+                                "def": {
+                                  "type": "literal",
+                                  "values": [
+                                    "metadata"
+                                  ]
+                                },
+                                "type": "literal",
+                                "values": {}
+                              }
+                            }
+                          },
+                          "type": "object"
+                        },
+                        {
+                          "def": {
+                            "type": "object",
+                            "shape": {
+                              "type": {
+                                "def": {
+                                  "type": "literal",
+                                  "values": [
+                                    "licenseSearch"
+                                  ]
+                                },
+                                "type": "literal",
+                                "values": {}
+                              },
+                              "meta": {
+                                "def": {
+                                  "type": "object",
+                                  "shape": {
+                                    "schemaVersion": {
+                                      "def": {
+                                        "type": "default",
+                                        "innerType": {
+                                          "def": {
+                                            "type": "string"
+                                          },
+                                          "type": "string",
+                                          "format": null,
+                                          "minLength": null,
+                                          "maxLength": null
+                                        },
+                                        "defaultValue": "1.0"
+                                      },
+                                      "type": "default"
+                                    }
+                                  }
+                                },
+                                "type": "object"
+                              },
+                              "comment": {
                                 "def": {
                                   "type": "optional",
                                   "innerType": {
@@ -3397,6 +3486,109 @@
                                   }
                                 },
                                 "type": "optional"
+                              },
+                              "answer": {
+                                "def": {
+                                  "type": "default",
+                                  "innerType": {
+                                    "def": {
+                                      "type": "array",
+                                      "element": {
+                                        "def": {
+                                          "type": "object",
+                                          "shape": {
+                                            "licenseId": {
+                                              "def": {
+                                                "type": "default",
+                                                "innerType": {
+                                                  "def": {
+                                                    "type": "string"
+                                                  },
+                                                  "type": "string",
+                                                  "format": null,
+                                                  "minLength": null,
+                                                  "maxLength": null
+                                                },
+                                                "defaultValue": ""
+                                              },
+                                              "type": "default"
+                                            },
+                                            "licenseName": {
+                                              "def": {
+                                                "type": "default",
+                                                "innerType": {
+                                                  "def": {
+                                                    "type": "string"
+                                                  },
+                                                  "type": "string",
+                                                  "format": null,
+                                                  "minLength": null,
+                                                  "maxLength": null
+                                                },
+                                                "defaultValue": ""
+                                              },
+                                              "type": "default"
+                                            }
+                                          }
+                                        },
+                                        "type": "object"
+                                      }
+                                    },
+                                    "type": "array",
+                                    "element": {
+                                      "def": {
+                                        "type": "object",
+                                        "shape": {
+                                          "licenseId": {
+                                            "def": {
+                                              "type": "default",
+                                              "innerType": {
+                                                "def": {
+                                                  "type": "string"
+                                                },
+                                                "type": "string",
+                                                "format": null,
+                                                "minLength": null,
+                                                "maxLength": null
+                                              },
+                                              "defaultValue": ""
+                                            },
+                                            "type": "default"
+                                          },
+                                          "licenseName": {
+                                            "def": {
+                                              "type": "default",
+                                              "innerType": {
+                                                "def": {
+                                                  "type": "string"
+                                                },
+                                                "type": "string",
+                                                "format": null,
+                                                "minLength": null,
+                                                "maxLength": null
+                                              },
+                                              "defaultValue": ""
+                                            },
+                                            "type": "default"
+                                          }
+                                        }
+                                      },
+                                      "type": "object"
+                                    }
+                                  },
+                                  "defaultValue": []
+                                },
+                                "type": "default"
+                              },
+                              "commonStandardId": {
+                                "def": {
+                                  "type": "literal",
+                                  "values": [
+                                    "license_ref"
+                                  ]
+                                },
+                                "type": "literal",
+                                "values": {}
                               }
                             }
                           },
@@ -3473,117 +3665,273 @@
                               },
                               "commonStandardId": {
                                 "def": {
-                                  "type": "optional",
-                                  "innerType": {
-                                    "def": {
-                                      "type": "string"
-                                    },
-                                    "type": "string",
-                                    "format": null,
-                                    "minLength": null,
-                                    "maxLength": null
-                                  }
-                                },
-                                "type": "optional"
-                              }
-                            }
-                          },
-                          "type": "object"
-                        },
-                        {
-                          "def": {
-                            "type": "object",
-                            "shape": {
-                              "type": {
-                                "def": {
                                   "type": "literal",
                                   "values": [
-                                    "textArea"
+                                    "custom"
                                   ]
                                 },
                                 "type": "literal",
                                 "values": {}
-                              },
-                              "meta": {
-                                "def": {
-                                  "type": "object",
-                                  "shape": {
-                                    "schemaVersion": {
-                                      "def": {
-                                        "type": "default",
-                                        "innerType": {
-                                          "def": {
-                                            "type": "string"
-                                          },
-                                          "type": "string",
-                                          "format": null,
-                                          "minLength": null,
-                                          "maxLength": null
-                                        },
-                                        "defaultValue": "1.0"
-                                      },
-                                      "type": "default"
-                                    }
-                                  }
-                                },
-                                "type": "object"
-                              },
-                              "comment": {
-                                "def": {
-                                  "type": "optional",
-                                  "innerType": {
-                                    "def": {
-                                      "type": "string"
-                                    },
-                                    "type": "string",
-                                    "format": null,
-                                    "minLength": null,
-                                    "maxLength": null
-                                  }
-                                },
-                                "type": "optional"
-                              },
-                              "answer": {
-                                "def": {
-                                  "type": "default",
-                                  "innerType": {
-                                    "def": {
-                                      "type": "string"
-                                    },
-                                    "type": "string",
-                                    "format": null,
-                                    "minLength": null,
-                                    "maxLength": null
-                                  },
-                                  "defaultValue": ""
-                                },
-                                "type": "default"
-                              },
-                              "commonStandardId": {
-                                "def": {
-                                  "type": "optional",
-                                  "innerType": {
-                                    "def": {
-                                      "type": "string"
-                                    },
-                                    "type": "string",
-                                    "format": null,
-                                    "minLength": null,
-                                    "maxLength": null
-                                  }
-                                },
-                                "type": "optional"
                               }
                             }
                           },
                           "type": "object"
                         }
                       ],
-                      "discriminator": "type",
+                      "discriminator": "commonStandardId",
                       "inclusive": false
                     },
                     "type": "union",
                     "options": [
+                      {
+                        "def": {
+                          "type": "object",
+                          "shape": {
+                            "type": {
+                              "def": {
+                                "type": "literal",
+                                "values": [
+                                  "text"
+                                ]
+                              },
+                              "type": "literal",
+                              "values": {}
+                            },
+                            "meta": {
+                              "def": {
+                                "type": "object",
+                                "shape": {
+                                  "schemaVersion": {
+                                    "def": {
+                                      "type": "default",
+                                      "innerType": {
+                                        "def": {
+                                          "type": "string"
+                                        },
+                                        "type": "string",
+                                        "format": null,
+                                        "minLength": null,
+                                        "maxLength": null
+                                      },
+                                      "defaultValue": "1.0"
+                                    },
+                                    "type": "default"
+                                  }
+                                }
+                              },
+                              "type": "object"
+                            },
+                            "comment": {
+                              "def": {
+                                "type": "optional",
+                                "innerType": {
+                                  "def": {
+                                    "type": "string"
+                                  },
+                                  "type": "string",
+                                  "format": null,
+                                  "minLength": null,
+                                  "maxLength": null
+                                }
+                              },
+                              "type": "optional"
+                            },
+                            "answer": {
+                              "def": {
+                                "type": "default",
+                                "innerType": {
+                                  "def": {
+                                    "type": "string"
+                                  },
+                                  "type": "string",
+                                  "format": null,
+                                  "minLength": null,
+                                  "maxLength": null
+                                },
+                                "defaultValue": ""
+                              },
+                              "type": "default"
+                            },
+                            "commonStandardId": {
+                              "def": {
+                                "type": "literal",
+                                "values": [
+                                  "title"
+                                ]
+                              },
+                              "type": "literal",
+                              "values": {}
+                            }
+                          }
+                        },
+                        "type": "object"
+                      },
+                      {
+                        "def": {
+                          "type": "object",
+                          "shape": {
+                            "type": {
+                              "def": {
+                                "type": "literal",
+                                "values": [
+                                  "textArea"
+                                ]
+                              },
+                              "type": "literal",
+                              "values": {}
+                            },
+                            "meta": {
+                              "def": {
+                                "type": "object",
+                                "shape": {
+                                  "schemaVersion": {
+                                    "def": {
+                                      "type": "default",
+                                      "innerType": {
+                                        "def": {
+                                          "type": "string"
+                                        },
+                                        "type": "string",
+                                        "format": null,
+                                        "minLength": null,
+                                        "maxLength": null
+                                      },
+                                      "defaultValue": "1.0"
+                                    },
+                                    "type": "default"
+                                  }
+                                }
+                              },
+                              "type": "object"
+                            },
+                            "comment": {
+                              "def": {
+                                "type": "optional",
+                                "innerType": {
+                                  "def": {
+                                    "type": "string"
+                                  },
+                                  "type": "string",
+                                  "format": null,
+                                  "minLength": null,
+                                  "maxLength": null
+                                }
+                              },
+                              "type": "optional"
+                            },
+                            "answer": {
+                              "def": {
+                                "type": "default",
+                                "innerType": {
+                                  "def": {
+                                    "type": "string"
+                                  },
+                                  "type": "string",
+                                  "format": null,
+                                  "minLength": null,
+                                  "maxLength": null
+                                },
+                                "defaultValue": ""
+                              },
+                              "type": "default"
+                            },
+                            "commonStandardId": {
+                              "def": {
+                                "type": "literal",
+                                "values": [
+                                  "description"
+                                ]
+                              },
+                              "type": "literal",
+                              "values": {}
+                            }
+                          }
+                        },
+                        "type": "object"
+                      },
+                      {
+                        "def": {
+                          "type": "object",
+                          "shape": {
+                            "type": {
+                              "def": {
+                                "type": "literal",
+                                "values": [
+                                  "selectBox"
+                                ]
+                              },
+                              "type": "literal",
+                              "values": {}
+                            },
+                            "meta": {
+                              "def": {
+                                "type": "object",
+                                "shape": {
+                                  "schemaVersion": {
+                                    "def": {
+                                      "type": "default",
+                                      "innerType": {
+                                        "def": {
+                                          "type": "string"
+                                        },
+                                        "type": "string",
+                                        "format": null,
+                                        "minLength": null,
+                                        "maxLength": null
+                                      },
+                                      "defaultValue": "1.0"
+                                    },
+                                    "type": "default"
+                                  }
+                                }
+                              },
+                              "type": "object"
+                            },
+                            "comment": {
+                              "def": {
+                                "type": "optional",
+                                "innerType": {
+                                  "def": {
+                                    "type": "string"
+                                  },
+                                  "type": "string",
+                                  "format": null,
+                                  "minLength": null,
+                                  "maxLength": null
+                                }
+                              },
+                              "type": "optional"
+                            },
+                            "answer": {
+                              "def": {
+                                "type": "default",
+                                "innerType": {
+                                  "def": {
+                                    "type": "string"
+                                  },
+                                  "type": "string",
+                                  "format": null,
+                                  "minLength": null,
+                                  "maxLength": null
+                                },
+                                "defaultValue": ""
+                              },
+                              "type": "default"
+                            },
+                            "commonStandardId": {
+                              "def": {
+                                "type": "literal",
+                                "values": [
+                                  "type"
+                                ]
+                              },
+                              "type": "literal",
+                              "values": {}
+                            }
+                          }
+                        },
+                        "type": "object"
+                      },
                       {
                         "def": {
                           "type": "object",
@@ -3672,6 +4020,58 @@
                             },
                             "commonStandardId": {
                               "def": {
+                                "type": "literal",
+                                "values": [
+                                  "data_flags"
+                                ]
+                              },
+                              "type": "literal",
+                              "values": {}
+                            }
+                          }
+                        },
+                        "type": "object"
+                      },
+                      {
+                        "def": {
+                          "type": "object",
+                          "shape": {
+                            "type": {
+                              "def": {
+                                "type": "literal",
+                                "values": [
+                                  "radioButtons"
+                                ]
+                              },
+                              "type": "literal",
+                              "values": {}
+                            },
+                            "meta": {
+                              "def": {
+                                "type": "object",
+                                "shape": {
+                                  "schemaVersion": {
+                                    "def": {
+                                      "type": "default",
+                                      "innerType": {
+                                        "def": {
+                                          "type": "string"
+                                        },
+                                        "type": "string",
+                                        "format": null,
+                                        "minLength": null,
+                                        "maxLength": null
+                                      },
+                                      "defaultValue": "1.0"
+                                    },
+                                    "type": "default"
+                                  }
+                                }
+                              },
+                              "type": "object"
+                            },
+                            "comment": {
+                              "def": {
                                 "type": "optional",
                                 "innerType": {
                                   "def": {
@@ -3684,6 +4084,32 @@
                                 }
                               },
                               "type": "optional"
+                            },
+                            "answer": {
+                              "def": {
+                                "type": "default",
+                                "innerType": {
+                                  "def": {
+                                    "type": "string"
+                                  },
+                                  "type": "string",
+                                  "format": null,
+                                  "minLength": null,
+                                  "maxLength": null
+                                },
+                                "defaultValue": ""
+                              },
+                              "type": "default"
+                            },
+                            "commonStandardId": {
+                              "def": {
+                                "type": "literal",
+                                "values": [
+                                  "data_access"
+                                ]
+                              },
+                              "type": "literal",
+                              "values": {}
                             }
                           }
                         },
@@ -3760,348 +4186,13 @@
                             },
                             "commonStandardId": {
                               "def": {
-                                "type": "optional",
-                                "innerType": {
-                                  "def": {
-                                    "type": "string"
-                                  },
-                                  "type": "string",
-                                  "format": null,
-                                  "minLength": null,
-                                  "maxLength": null
-                                }
-                              },
-                              "type": "optional"
-                            }
-                          }
-                        },
-                        "type": "object"
-                      },
-                      {
-                        "def": {
-                          "type": "object",
-                          "shape": {
-                            "type": {
-                              "def": {
                                 "type": "literal",
                                 "values": [
-                                  "licenseSearch"
+                                  "issued"
                                 ]
                               },
                               "type": "literal",
                               "values": {}
-                            },
-                            "meta": {
-                              "def": {
-                                "type": "object",
-                                "shape": {
-                                  "schemaVersion": {
-                                    "def": {
-                                      "type": "default",
-                                      "innerType": {
-                                        "def": {
-                                          "type": "string"
-                                        },
-                                        "type": "string",
-                                        "format": null,
-                                        "minLength": null,
-                                        "maxLength": null
-                                      },
-                                      "defaultValue": "1.0"
-                                    },
-                                    "type": "default"
-                                  }
-                                }
-                              },
-                              "type": "object"
-                            },
-                            "comment": {
-                              "def": {
-                                "type": "optional",
-                                "innerType": {
-                                  "def": {
-                                    "type": "string"
-                                  },
-                                  "type": "string",
-                                  "format": null,
-                                  "minLength": null,
-                                  "maxLength": null
-                                }
-                              },
-                              "type": "optional"
-                            },
-                            "answer": {
-                              "def": {
-                                "type": "default",
-                                "innerType": {
-                                  "def": {
-                                    "type": "array",
-                                    "element": {
-                                      "def": {
-                                        "type": "object",
-                                        "shape": {
-                                          "licenseId": {
-                                            "def": {
-                                              "type": "default",
-                                              "innerType": {
-                                                "def": {
-                                                  "type": "string"
-                                                },
-                                                "type": "string",
-                                                "format": null,
-                                                "minLength": null,
-                                                "maxLength": null
-                                              },
-                                              "defaultValue": ""
-                                            },
-                                            "type": "default"
-                                          },
-                                          "licenseName": {
-                                            "def": {
-                                              "type": "default",
-                                              "innerType": {
-                                                "def": {
-                                                  "type": "string"
-                                                },
-                                                "type": "string",
-                                                "format": null,
-                                                "minLength": null,
-                                                "maxLength": null
-                                              },
-                                              "defaultValue": ""
-                                            },
-                                            "type": "default"
-                                          }
-                                        }
-                                      },
-                                      "type": "object"
-                                    }
-                                  },
-                                  "type": "array",
-                                  "element": {
-                                    "def": {
-                                      "type": "object",
-                                      "shape": {
-                                        "licenseId": {
-                                          "def": {
-                                            "type": "default",
-                                            "innerType": {
-                                              "def": {
-                                                "type": "string"
-                                              },
-                                              "type": "string",
-                                              "format": null,
-                                              "minLength": null,
-                                              "maxLength": null
-                                            },
-                                            "defaultValue": ""
-                                          },
-                                          "type": "default"
-                                        },
-                                        "licenseName": {
-                                          "def": {
-                                            "type": "default",
-                                            "innerType": {
-                                              "def": {
-                                                "type": "string"
-                                              },
-                                              "type": "string",
-                                              "format": null,
-                                              "minLength": null,
-                                              "maxLength": null
-                                            },
-                                            "defaultValue": ""
-                                          },
-                                          "type": "default"
-                                        }
-                                      }
-                                    },
-                                    "type": "object"
-                                  }
-                                },
-                                "defaultValue": []
-                              },
-                              "type": "default"
-                            },
-                            "commonStandardId": {
-                              "def": {
-                                "type": "optional",
-                                "innerType": {
-                                  "def": {
-                                    "type": "string"
-                                  },
-                                  "type": "string",
-                                  "format": null,
-                                  "minLength": null,
-                                  "maxLength": null
-                                }
-                              },
-                              "type": "optional"
-                            }
-                          }
-                        },
-                        "type": "object"
-                      },
-                      {
-                        "def": {
-                          "type": "object",
-                          "shape": {
-                            "type": {
-                              "def": {
-                                "type": "literal",
-                                "values": [
-                                  "metadataStandardSearch"
-                                ]
-                              },
-                              "type": "literal",
-                              "values": {}
-                            },
-                            "meta": {
-                              "def": {
-                                "type": "object",
-                                "shape": {
-                                  "schemaVersion": {
-                                    "def": {
-                                      "type": "default",
-                                      "innerType": {
-                                        "def": {
-                                          "type": "string"
-                                        },
-                                        "type": "string",
-                                        "format": null,
-                                        "minLength": null,
-                                        "maxLength": null
-                                      },
-                                      "defaultValue": "1.0"
-                                    },
-                                    "type": "default"
-                                  }
-                                }
-                              },
-                              "type": "object"
-                            },
-                            "comment": {
-                              "def": {
-                                "type": "optional",
-                                "innerType": {
-                                  "def": {
-                                    "type": "string"
-                                  },
-                                  "type": "string",
-                                  "format": null,
-                                  "minLength": null,
-                                  "maxLength": null
-                                }
-                              },
-                              "type": "optional"
-                            },
-                            "answer": {
-                              "def": {
-                                "type": "default",
-                                "innerType": {
-                                  "def": {
-                                    "type": "array",
-                                    "element": {
-                                      "def": {
-                                        "type": "object",
-                                        "shape": {
-                                          "metadataStandardId": {
-                                            "def": {
-                                              "type": "default",
-                                              "innerType": {
-                                                "def": {
-                                                  "type": "string"
-                                                },
-                                                "type": "string",
-                                                "format": null,
-                                                "minLength": null,
-                                                "maxLength": null
-                                              },
-                                              "defaultValue": ""
-                                            },
-                                            "type": "default"
-                                          },
-                                          "metadataStandardName": {
-                                            "def": {
-                                              "type": "default",
-                                              "innerType": {
-                                                "def": {
-                                                  "type": "string"
-                                                },
-                                                "type": "string",
-                                                "format": null,
-                                                "minLength": null,
-                                                "maxLength": null
-                                              },
-                                              "defaultValue": ""
-                                            },
-                                            "type": "default"
-                                          }
-                                        }
-                                      },
-                                      "type": "object"
-                                    }
-                                  },
-                                  "type": "array",
-                                  "element": {
-                                    "def": {
-                                      "type": "object",
-                                      "shape": {
-                                        "metadataStandardId": {
-                                          "def": {
-                                            "type": "default",
-                                            "innerType": {
-                                              "def": {
-                                                "type": "string"
-                                              },
-                                              "type": "string",
-                                              "format": null,
-                                              "minLength": null,
-                                              "maxLength": null
-                                            },
-                                            "defaultValue": ""
-                                          },
-                                          "type": "default"
-                                        },
-                                        "metadataStandardName": {
-                                          "def": {
-                                            "type": "default",
-                                            "innerType": {
-                                              "def": {
-                                                "type": "string"
-                                              },
-                                              "type": "string",
-                                              "format": null,
-                                              "minLength": null,
-                                              "maxLength": null
-                                            },
-                                            "defaultValue": ""
-                                          },
-                                          "type": "default"
-                                        }
-                                      }
-                                    },
-                                    "type": "object"
-                                  }
-                                },
-                                "defaultValue": []
-                              },
-                              "type": "default"
-                            },
-                            "commonStandardId": {
-                              "def": {
-                                "type": "optional",
-                                "innerType": {
-                                  "def": {
-                                    "type": "string"
-                                  },
-                                  "type": "string",
-                                  "format": null,
-                                  "minLength": null,
-                                  "maxLength": null
-                                }
-                              },
-                              "type": "optional"
                             }
                           }
                         },
@@ -4205,106 +4296,13 @@
                             },
                             "commonStandardId": {
                               "def": {
-                                "type": "optional",
-                                "innerType": {
-                                  "def": {
-                                    "type": "string"
-                                  },
-                                  "type": "string",
-                                  "format": null,
-                                  "minLength": null,
-                                  "maxLength": null
-                                }
-                              },
-                              "type": "optional"
-                            }
-                          }
-                        },
-                        "type": "object"
-                      },
-                      {
-                        "def": {
-                          "type": "object",
-                          "shape": {
-                            "type": {
-                              "def": {
                                 "type": "literal",
                                 "values": [
-                                  "radioButtons"
+                                  "byte_size"
                                 ]
                               },
                               "type": "literal",
                               "values": {}
-                            },
-                            "meta": {
-                              "def": {
-                                "type": "object",
-                                "shape": {
-                                  "schemaVersion": {
-                                    "def": {
-                                      "type": "default",
-                                      "innerType": {
-                                        "def": {
-                                          "type": "string"
-                                        },
-                                        "type": "string",
-                                        "format": null,
-                                        "minLength": null,
-                                        "maxLength": null
-                                      },
-                                      "defaultValue": "1.0"
-                                    },
-                                    "type": "default"
-                                  }
-                                }
-                              },
-                              "type": "object"
-                            },
-                            "comment": {
-                              "def": {
-                                "type": "optional",
-                                "innerType": {
-                                  "def": {
-                                    "type": "string"
-                                  },
-                                  "type": "string",
-                                  "format": null,
-                                  "minLength": null,
-                                  "maxLength": null
-                                }
-                              },
-                              "type": "optional"
-                            },
-                            "answer": {
-                              "def": {
-                                "type": "default",
-                                "innerType": {
-                                  "def": {
-                                    "type": "string"
-                                  },
-                                  "type": "string",
-                                  "format": null,
-                                  "minLength": null,
-                                  "maxLength": null
-                                },
-                                "defaultValue": ""
-                              },
-                              "type": "default"
-                            },
-                            "commonStandardId": {
-                              "def": {
-                                "type": "optional",
-                                "innerType": {
-                                  "def": {
-                                    "type": "string"
-                                  },
-                                  "type": "string",
-                                  "format": null,
-                                  "minLength": null,
-                                  "maxLength": null
-                                }
-                              },
-                              "type": "optional"
                             }
                           }
                         },
@@ -4458,18 +4456,13 @@
                             },
                             "commonStandardId": {
                               "def": {
-                                "type": "optional",
-                                "innerType": {
-                                  "def": {
-                                    "type": "string"
-                                  },
-                                  "type": "string",
-                                  "format": null,
-                                  "minLength": null,
-                                  "maxLength": null
-                                }
+                                "type": "literal",
+                                "values": [
+                                  "host"
+                                ]
                               },
-                              "type": "optional"
+                              "type": "literal",
+                              "values": {}
                             }
                           }
                         },
@@ -4483,7 +4476,7 @@
                               "def": {
                                 "type": "literal",
                                 "values": [
-                                  "selectBox"
+                                  "metadataStandardSearch"
                                 ]
                               },
                               "type": "literal",
@@ -4533,18 +4526,147 @@
                                 "type": "default",
                                 "innerType": {
                                   "def": {
-                                    "type": "string"
+                                    "type": "array",
+                                    "element": {
+                                      "def": {
+                                        "type": "object",
+                                        "shape": {
+                                          "metadataStandardId": {
+                                            "def": {
+                                              "type": "default",
+                                              "innerType": {
+                                                "def": {
+                                                  "type": "string"
+                                                },
+                                                "type": "string",
+                                                "format": null,
+                                                "minLength": null,
+                                                "maxLength": null
+                                              },
+                                              "defaultValue": ""
+                                            },
+                                            "type": "default"
+                                          },
+                                          "metadataStandardName": {
+                                            "def": {
+                                              "type": "default",
+                                              "innerType": {
+                                                "def": {
+                                                  "type": "string"
+                                                },
+                                                "type": "string",
+                                                "format": null,
+                                                "minLength": null,
+                                                "maxLength": null
+                                              },
+                                              "defaultValue": ""
+                                            },
+                                            "type": "default"
+                                          }
+                                        }
+                                      },
+                                      "type": "object"
+                                    }
                                   },
-                                  "type": "string",
-                                  "format": null,
-                                  "minLength": null,
-                                  "maxLength": null
+                                  "type": "array",
+                                  "element": {
+                                    "def": {
+                                      "type": "object",
+                                      "shape": {
+                                        "metadataStandardId": {
+                                          "def": {
+                                            "type": "default",
+                                            "innerType": {
+                                              "def": {
+                                                "type": "string"
+                                              },
+                                              "type": "string",
+                                              "format": null,
+                                              "minLength": null,
+                                              "maxLength": null
+                                            },
+                                            "defaultValue": ""
+                                          },
+                                          "type": "default"
+                                        },
+                                        "metadataStandardName": {
+                                          "def": {
+                                            "type": "default",
+                                            "innerType": {
+                                              "def": {
+                                                "type": "string"
+                                              },
+                                              "type": "string",
+                                              "format": null,
+                                              "minLength": null,
+                                              "maxLength": null
+                                            },
+                                            "defaultValue": ""
+                                          },
+                                          "type": "default"
+                                        }
+                                      }
+                                    },
+                                    "type": "object"
+                                  }
                                 },
-                                "defaultValue": ""
+                                "defaultValue": []
                               },
                               "type": "default"
                             },
                             "commonStandardId": {
+                              "def": {
+                                "type": "literal",
+                                "values": [
+                                  "metadata"
+                                ]
+                              },
+                              "type": "literal",
+                              "values": {}
+                            }
+                          }
+                        },
+                        "type": "object"
+                      },
+                      {
+                        "def": {
+                          "type": "object",
+                          "shape": {
+                            "type": {
+                              "def": {
+                                "type": "literal",
+                                "values": [
+                                  "licenseSearch"
+                                ]
+                              },
+                              "type": "literal",
+                              "values": {}
+                            },
+                            "meta": {
+                              "def": {
+                                "type": "object",
+                                "shape": {
+                                  "schemaVersion": {
+                                    "def": {
+                                      "type": "default",
+                                      "innerType": {
+                                        "def": {
+                                          "type": "string"
+                                        },
+                                        "type": "string",
+                                        "format": null,
+                                        "minLength": null,
+                                        "maxLength": null
+                                      },
+                                      "defaultValue": "1.0"
+                                    },
+                                    "type": "default"
+                                  }
+                                }
+                              },
+                              "type": "object"
+                            },
+                            "comment": {
                               "def": {
                                 "type": "optional",
                                 "innerType": {
@@ -4558,6 +4680,109 @@
                                 }
                               },
                               "type": "optional"
+                            },
+                            "answer": {
+                              "def": {
+                                "type": "default",
+                                "innerType": {
+                                  "def": {
+                                    "type": "array",
+                                    "element": {
+                                      "def": {
+                                        "type": "object",
+                                        "shape": {
+                                          "licenseId": {
+                                            "def": {
+                                              "type": "default",
+                                              "innerType": {
+                                                "def": {
+                                                  "type": "string"
+                                                },
+                                                "type": "string",
+                                                "format": null,
+                                                "minLength": null,
+                                                "maxLength": null
+                                              },
+                                              "defaultValue": ""
+                                            },
+                                            "type": "default"
+                                          },
+                                          "licenseName": {
+                                            "def": {
+                                              "type": "default",
+                                              "innerType": {
+                                                "def": {
+                                                  "type": "string"
+                                                },
+                                                "type": "string",
+                                                "format": null,
+                                                "minLength": null,
+                                                "maxLength": null
+                                              },
+                                              "defaultValue": ""
+                                            },
+                                            "type": "default"
+                                          }
+                                        }
+                                      },
+                                      "type": "object"
+                                    }
+                                  },
+                                  "type": "array",
+                                  "element": {
+                                    "def": {
+                                      "type": "object",
+                                      "shape": {
+                                        "licenseId": {
+                                          "def": {
+                                            "type": "default",
+                                            "innerType": {
+                                              "def": {
+                                                "type": "string"
+                                              },
+                                              "type": "string",
+                                              "format": null,
+                                              "minLength": null,
+                                              "maxLength": null
+                                            },
+                                            "defaultValue": ""
+                                          },
+                                          "type": "default"
+                                        },
+                                        "licenseName": {
+                                          "def": {
+                                            "type": "default",
+                                            "innerType": {
+                                              "def": {
+                                                "type": "string"
+                                              },
+                                              "type": "string",
+                                              "format": null,
+                                              "minLength": null,
+                                              "maxLength": null
+                                            },
+                                            "defaultValue": ""
+                                          },
+                                          "type": "default"
+                                        }
+                                      }
+                                    },
+                                    "type": "object"
+                                  }
+                                },
+                                "defaultValue": []
+                              },
+                              "type": "default"
+                            },
+                            "commonStandardId": {
+                              "def": {
+                                "type": "literal",
+                                "values": [
+                                  "license_ref"
+                                ]
+                              },
+                              "type": "literal",
+                              "values": {}
                             }
                           }
                         },
@@ -4634,106 +4859,13 @@
                             },
                             "commonStandardId": {
                               "def": {
-                                "type": "optional",
-                                "innerType": {
-                                  "def": {
-                                    "type": "string"
-                                  },
-                                  "type": "string",
-                                  "format": null,
-                                  "minLength": null,
-                                  "maxLength": null
-                                }
-                              },
-                              "type": "optional"
-                            }
-                          }
-                        },
-                        "type": "object"
-                      },
-                      {
-                        "def": {
-                          "type": "object",
-                          "shape": {
-                            "type": {
-                              "def": {
                                 "type": "literal",
                                 "values": [
-                                  "textArea"
+                                  "custom"
                                 ]
                               },
                               "type": "literal",
                               "values": {}
-                            },
-                            "meta": {
-                              "def": {
-                                "type": "object",
-                                "shape": {
-                                  "schemaVersion": {
-                                    "def": {
-                                      "type": "default",
-                                      "innerType": {
-                                        "def": {
-                                          "type": "string"
-                                        },
-                                        "type": "string",
-                                        "format": null,
-                                        "minLength": null,
-                                        "maxLength": null
-                                      },
-                                      "defaultValue": "1.0"
-                                    },
-                                    "type": "default"
-                                  }
-                                }
-                              },
-                              "type": "object"
-                            },
-                            "comment": {
-                              "def": {
-                                "type": "optional",
-                                "innerType": {
-                                  "def": {
-                                    "type": "string"
-                                  },
-                                  "type": "string",
-                                  "format": null,
-                                  "minLength": null,
-                                  "maxLength": null
-                                }
-                              },
-                              "type": "optional"
-                            },
-                            "answer": {
-                              "def": {
-                                "type": "default",
-                                "innerType": {
-                                  "def": {
-                                    "type": "string"
-                                  },
-                                  "type": "string",
-                                  "format": null,
-                                  "minLength": null,
-                                  "maxLength": null
-                                },
-                                "defaultValue": ""
-                              },
-                              "type": "default"
-                            },
-                            "commonStandardId": {
-                              "def": {
-                                "type": "optional",
-                                "innerType": {
-                                  "def": {
-                                    "type": "string"
-                                  },
-                                  "type": "string",
-                                  "format": null,
-                                  "minLength": null,
-                                  "maxLength": null
-                                }
-                              },
-                              "type": "optional"
                             }
                           }
                         },
@@ -4767,6 +4899,255 @@
                                 "def": {
                                   "type": "literal",
                                   "values": [
+                                    "text"
+                                  ]
+                                },
+                                "type": "literal",
+                                "values": {}
+                              },
+                              "meta": {
+                                "def": {
+                                  "type": "object",
+                                  "shape": {
+                                    "schemaVersion": {
+                                      "def": {
+                                        "type": "default",
+                                        "innerType": {
+                                          "def": {
+                                            "type": "string"
+                                          },
+                                          "type": "string",
+                                          "format": null,
+                                          "minLength": null,
+                                          "maxLength": null
+                                        },
+                                        "defaultValue": "1.0"
+                                      },
+                                      "type": "default"
+                                    }
+                                  }
+                                },
+                                "type": "object"
+                              },
+                              "comment": {
+                                "def": {
+                                  "type": "optional",
+                                  "innerType": {
+                                    "def": {
+                                      "type": "string"
+                                    },
+                                    "type": "string",
+                                    "format": null,
+                                    "minLength": null,
+                                    "maxLength": null
+                                  }
+                                },
+                                "type": "optional"
+                              },
+                              "answer": {
+                                "def": {
+                                  "type": "default",
+                                  "innerType": {
+                                    "def": {
+                                      "type": "string"
+                                    },
+                                    "type": "string",
+                                    "format": null,
+                                    "minLength": null,
+                                    "maxLength": null
+                                  },
+                                  "defaultValue": ""
+                                },
+                                "type": "default"
+                              },
+                              "commonStandardId": {
+                                "def": {
+                                  "type": "literal",
+                                  "values": [
+                                    "title"
+                                  ]
+                                },
+                                "type": "literal",
+                                "values": {}
+                              }
+                            }
+                          },
+                          "type": "object"
+                        },
+                        {
+                          "def": {
+                            "type": "object",
+                            "shape": {
+                              "type": {
+                                "def": {
+                                  "type": "literal",
+                                  "values": [
+                                    "textArea"
+                                  ]
+                                },
+                                "type": "literal",
+                                "values": {}
+                              },
+                              "meta": {
+                                "def": {
+                                  "type": "object",
+                                  "shape": {
+                                    "schemaVersion": {
+                                      "def": {
+                                        "type": "default",
+                                        "innerType": {
+                                          "def": {
+                                            "type": "string"
+                                          },
+                                          "type": "string",
+                                          "format": null,
+                                          "minLength": null,
+                                          "maxLength": null
+                                        },
+                                        "defaultValue": "1.0"
+                                      },
+                                      "type": "default"
+                                    }
+                                  }
+                                },
+                                "type": "object"
+                              },
+                              "comment": {
+                                "def": {
+                                  "type": "optional",
+                                  "innerType": {
+                                    "def": {
+                                      "type": "string"
+                                    },
+                                    "type": "string",
+                                    "format": null,
+                                    "minLength": null,
+                                    "maxLength": null
+                                  }
+                                },
+                                "type": "optional"
+                              },
+                              "answer": {
+                                "def": {
+                                  "type": "default",
+                                  "innerType": {
+                                    "def": {
+                                      "type": "string"
+                                    },
+                                    "type": "string",
+                                    "format": null,
+                                    "minLength": null,
+                                    "maxLength": null
+                                  },
+                                  "defaultValue": ""
+                                },
+                                "type": "default"
+                              },
+                              "commonStandardId": {
+                                "def": {
+                                  "type": "literal",
+                                  "values": [
+                                    "description"
+                                  ]
+                                },
+                                "type": "literal",
+                                "values": {}
+                              }
+                            }
+                          },
+                          "type": "object"
+                        },
+                        {
+                          "def": {
+                            "type": "object",
+                            "shape": {
+                              "type": {
+                                "def": {
+                                  "type": "literal",
+                                  "values": [
+                                    "selectBox"
+                                  ]
+                                },
+                                "type": "literal",
+                                "values": {}
+                              },
+                              "meta": {
+                                "def": {
+                                  "type": "object",
+                                  "shape": {
+                                    "schemaVersion": {
+                                      "def": {
+                                        "type": "default",
+                                        "innerType": {
+                                          "def": {
+                                            "type": "string"
+                                          },
+                                          "type": "string",
+                                          "format": null,
+                                          "minLength": null,
+                                          "maxLength": null
+                                        },
+                                        "defaultValue": "1.0"
+                                      },
+                                      "type": "default"
+                                    }
+                                  }
+                                },
+                                "type": "object"
+                              },
+                              "comment": {
+                                "def": {
+                                  "type": "optional",
+                                  "innerType": {
+                                    "def": {
+                                      "type": "string"
+                                    },
+                                    "type": "string",
+                                    "format": null,
+                                    "minLength": null,
+                                    "maxLength": null
+                                  }
+                                },
+                                "type": "optional"
+                              },
+                              "answer": {
+                                "def": {
+                                  "type": "default",
+                                  "innerType": {
+                                    "def": {
+                                      "type": "string"
+                                    },
+                                    "type": "string",
+                                    "format": null,
+                                    "minLength": null,
+                                    "maxLength": null
+                                  },
+                                  "defaultValue": ""
+                                },
+                                "type": "default"
+                              },
+                              "commonStandardId": {
+                                "def": {
+                                  "type": "literal",
+                                  "values": [
+                                    "type"
+                                  ]
+                                },
+                                "type": "literal",
+                                "values": {}
+                              }
+                            }
+                          },
+                          "type": "object"
+                        },
+                        {
+                          "def": {
+                            "type": "object",
+                            "shape": {
+                              "type": {
+                                "def": {
+                                  "type": "literal",
+                                  "values": [
                                     "checkBoxes"
                                   ]
                                 },
@@ -4847,6 +5228,58 @@
                               },
                               "commonStandardId": {
                                 "def": {
+                                  "type": "literal",
+                                  "values": [
+                                    "data_flags"
+                                  ]
+                                },
+                                "type": "literal",
+                                "values": {}
+                              }
+                            }
+                          },
+                          "type": "object"
+                        },
+                        {
+                          "def": {
+                            "type": "object",
+                            "shape": {
+                              "type": {
+                                "def": {
+                                  "type": "literal",
+                                  "values": [
+                                    "radioButtons"
+                                  ]
+                                },
+                                "type": "literal",
+                                "values": {}
+                              },
+                              "meta": {
+                                "def": {
+                                  "type": "object",
+                                  "shape": {
+                                    "schemaVersion": {
+                                      "def": {
+                                        "type": "default",
+                                        "innerType": {
+                                          "def": {
+                                            "type": "string"
+                                          },
+                                          "type": "string",
+                                          "format": null,
+                                          "minLength": null,
+                                          "maxLength": null
+                                        },
+                                        "defaultValue": "1.0"
+                                      },
+                                      "type": "default"
+                                    }
+                                  }
+                                },
+                                "type": "object"
+                              },
+                              "comment": {
+                                "def": {
                                   "type": "optional",
                                   "innerType": {
                                     "def": {
@@ -4859,6 +5292,32 @@
                                   }
                                 },
                                 "type": "optional"
+                              },
+                              "answer": {
+                                "def": {
+                                  "type": "default",
+                                  "innerType": {
+                                    "def": {
+                                      "type": "string"
+                                    },
+                                    "type": "string",
+                                    "format": null,
+                                    "minLength": null,
+                                    "maxLength": null
+                                  },
+                                  "defaultValue": ""
+                                },
+                                "type": "default"
+                              },
+                              "commonStandardId": {
+                                "def": {
+                                  "type": "literal",
+                                  "values": [
+                                    "data_access"
+                                  ]
+                                },
+                                "type": "literal",
+                                "values": {}
                               }
                             }
                           },
@@ -4935,348 +5394,13 @@
                               },
                               "commonStandardId": {
                                 "def": {
-                                  "type": "optional",
-                                  "innerType": {
-                                    "def": {
-                                      "type": "string"
-                                    },
-                                    "type": "string",
-                                    "format": null,
-                                    "minLength": null,
-                                    "maxLength": null
-                                  }
-                                },
-                                "type": "optional"
-                              }
-                            }
-                          },
-                          "type": "object"
-                        },
-                        {
-                          "def": {
-                            "type": "object",
-                            "shape": {
-                              "type": {
-                                "def": {
                                   "type": "literal",
                                   "values": [
-                                    "licenseSearch"
+                                    "issued"
                                   ]
                                 },
                                 "type": "literal",
                                 "values": {}
-                              },
-                              "meta": {
-                                "def": {
-                                  "type": "object",
-                                  "shape": {
-                                    "schemaVersion": {
-                                      "def": {
-                                        "type": "default",
-                                        "innerType": {
-                                          "def": {
-                                            "type": "string"
-                                          },
-                                          "type": "string",
-                                          "format": null,
-                                          "minLength": null,
-                                          "maxLength": null
-                                        },
-                                        "defaultValue": "1.0"
-                                      },
-                                      "type": "default"
-                                    }
-                                  }
-                                },
-                                "type": "object"
-                              },
-                              "comment": {
-                                "def": {
-                                  "type": "optional",
-                                  "innerType": {
-                                    "def": {
-                                      "type": "string"
-                                    },
-                                    "type": "string",
-                                    "format": null,
-                                    "minLength": null,
-                                    "maxLength": null
-                                  }
-                                },
-                                "type": "optional"
-                              },
-                              "answer": {
-                                "def": {
-                                  "type": "default",
-                                  "innerType": {
-                                    "def": {
-                                      "type": "array",
-                                      "element": {
-                                        "def": {
-                                          "type": "object",
-                                          "shape": {
-                                            "licenseId": {
-                                              "def": {
-                                                "type": "default",
-                                                "innerType": {
-                                                  "def": {
-                                                    "type": "string"
-                                                  },
-                                                  "type": "string",
-                                                  "format": null,
-                                                  "minLength": null,
-                                                  "maxLength": null
-                                                },
-                                                "defaultValue": ""
-                                              },
-                                              "type": "default"
-                                            },
-                                            "licenseName": {
-                                              "def": {
-                                                "type": "default",
-                                                "innerType": {
-                                                  "def": {
-                                                    "type": "string"
-                                                  },
-                                                  "type": "string",
-                                                  "format": null,
-                                                  "minLength": null,
-                                                  "maxLength": null
-                                                },
-                                                "defaultValue": ""
-                                              },
-                                              "type": "default"
-                                            }
-                                          }
-                                        },
-                                        "type": "object"
-                                      }
-                                    },
-                                    "type": "array",
-                                    "element": {
-                                      "def": {
-                                        "type": "object",
-                                        "shape": {
-                                          "licenseId": {
-                                            "def": {
-                                              "type": "default",
-                                              "innerType": {
-                                                "def": {
-                                                  "type": "string"
-                                                },
-                                                "type": "string",
-                                                "format": null,
-                                                "minLength": null,
-                                                "maxLength": null
-                                              },
-                                              "defaultValue": ""
-                                            },
-                                            "type": "default"
-                                          },
-                                          "licenseName": {
-                                            "def": {
-                                              "type": "default",
-                                              "innerType": {
-                                                "def": {
-                                                  "type": "string"
-                                                },
-                                                "type": "string",
-                                                "format": null,
-                                                "minLength": null,
-                                                "maxLength": null
-                                              },
-                                              "defaultValue": ""
-                                            },
-                                            "type": "default"
-                                          }
-                                        }
-                                      },
-                                      "type": "object"
-                                    }
-                                  },
-                                  "defaultValue": []
-                                },
-                                "type": "default"
-                              },
-                              "commonStandardId": {
-                                "def": {
-                                  "type": "optional",
-                                  "innerType": {
-                                    "def": {
-                                      "type": "string"
-                                    },
-                                    "type": "string",
-                                    "format": null,
-                                    "minLength": null,
-                                    "maxLength": null
-                                  }
-                                },
-                                "type": "optional"
-                              }
-                            }
-                          },
-                          "type": "object"
-                        },
-                        {
-                          "def": {
-                            "type": "object",
-                            "shape": {
-                              "type": {
-                                "def": {
-                                  "type": "literal",
-                                  "values": [
-                                    "metadataStandardSearch"
-                                  ]
-                                },
-                                "type": "literal",
-                                "values": {}
-                              },
-                              "meta": {
-                                "def": {
-                                  "type": "object",
-                                  "shape": {
-                                    "schemaVersion": {
-                                      "def": {
-                                        "type": "default",
-                                        "innerType": {
-                                          "def": {
-                                            "type": "string"
-                                          },
-                                          "type": "string",
-                                          "format": null,
-                                          "minLength": null,
-                                          "maxLength": null
-                                        },
-                                        "defaultValue": "1.0"
-                                      },
-                                      "type": "default"
-                                    }
-                                  }
-                                },
-                                "type": "object"
-                              },
-                              "comment": {
-                                "def": {
-                                  "type": "optional",
-                                  "innerType": {
-                                    "def": {
-                                      "type": "string"
-                                    },
-                                    "type": "string",
-                                    "format": null,
-                                    "minLength": null,
-                                    "maxLength": null
-                                  }
-                                },
-                                "type": "optional"
-                              },
-                              "answer": {
-                                "def": {
-                                  "type": "default",
-                                  "innerType": {
-                                    "def": {
-                                      "type": "array",
-                                      "element": {
-                                        "def": {
-                                          "type": "object",
-                                          "shape": {
-                                            "metadataStandardId": {
-                                              "def": {
-                                                "type": "default",
-                                                "innerType": {
-                                                  "def": {
-                                                    "type": "string"
-                                                  },
-                                                  "type": "string",
-                                                  "format": null,
-                                                  "minLength": null,
-                                                  "maxLength": null
-                                                },
-                                                "defaultValue": ""
-                                              },
-                                              "type": "default"
-                                            },
-                                            "metadataStandardName": {
-                                              "def": {
-                                                "type": "default",
-                                                "innerType": {
-                                                  "def": {
-                                                    "type": "string"
-                                                  },
-                                                  "type": "string",
-                                                  "format": null,
-                                                  "minLength": null,
-                                                  "maxLength": null
-                                                },
-                                                "defaultValue": ""
-                                              },
-                                              "type": "default"
-                                            }
-                                          }
-                                        },
-                                        "type": "object"
-                                      }
-                                    },
-                                    "type": "array",
-                                    "element": {
-                                      "def": {
-                                        "type": "object",
-                                        "shape": {
-                                          "metadataStandardId": {
-                                            "def": {
-                                              "type": "default",
-                                              "innerType": {
-                                                "def": {
-                                                  "type": "string"
-                                                },
-                                                "type": "string",
-                                                "format": null,
-                                                "minLength": null,
-                                                "maxLength": null
-                                              },
-                                              "defaultValue": ""
-                                            },
-                                            "type": "default"
-                                          },
-                                          "metadataStandardName": {
-                                            "def": {
-                                              "type": "default",
-                                              "innerType": {
-                                                "def": {
-                                                  "type": "string"
-                                                },
-                                                "type": "string",
-                                                "format": null,
-                                                "minLength": null,
-                                                "maxLength": null
-                                              },
-                                              "defaultValue": ""
-                                            },
-                                            "type": "default"
-                                          }
-                                        }
-                                      },
-                                      "type": "object"
-                                    }
-                                  },
-                                  "defaultValue": []
-                                },
-                                "type": "default"
-                              },
-                              "commonStandardId": {
-                                "def": {
-                                  "type": "optional",
-                                  "innerType": {
-                                    "def": {
-                                      "type": "string"
-                                    },
-                                    "type": "string",
-                                    "format": null,
-                                    "minLength": null,
-                                    "maxLength": null
-                                  }
-                                },
-                                "type": "optional"
                               }
                             }
                           },
@@ -5380,106 +5504,13 @@
                               },
                               "commonStandardId": {
                                 "def": {
-                                  "type": "optional",
-                                  "innerType": {
-                                    "def": {
-                                      "type": "string"
-                                    },
-                                    "type": "string",
-                                    "format": null,
-                                    "minLength": null,
-                                    "maxLength": null
-                                  }
-                                },
-                                "type": "optional"
-                              }
-                            }
-                          },
-                          "type": "object"
-                        },
-                        {
-                          "def": {
-                            "type": "object",
-                            "shape": {
-                              "type": {
-                                "def": {
                                   "type": "literal",
                                   "values": [
-                                    "radioButtons"
+                                    "byte_size"
                                   ]
                                 },
                                 "type": "literal",
                                 "values": {}
-                              },
-                              "meta": {
-                                "def": {
-                                  "type": "object",
-                                  "shape": {
-                                    "schemaVersion": {
-                                      "def": {
-                                        "type": "default",
-                                        "innerType": {
-                                          "def": {
-                                            "type": "string"
-                                          },
-                                          "type": "string",
-                                          "format": null,
-                                          "minLength": null,
-                                          "maxLength": null
-                                        },
-                                        "defaultValue": "1.0"
-                                      },
-                                      "type": "default"
-                                    }
-                                  }
-                                },
-                                "type": "object"
-                              },
-                              "comment": {
-                                "def": {
-                                  "type": "optional",
-                                  "innerType": {
-                                    "def": {
-                                      "type": "string"
-                                    },
-                                    "type": "string",
-                                    "format": null,
-                                    "minLength": null,
-                                    "maxLength": null
-                                  }
-                                },
-                                "type": "optional"
-                              },
-                              "answer": {
-                                "def": {
-                                  "type": "default",
-                                  "innerType": {
-                                    "def": {
-                                      "type": "string"
-                                    },
-                                    "type": "string",
-                                    "format": null,
-                                    "minLength": null,
-                                    "maxLength": null
-                                  },
-                                  "defaultValue": ""
-                                },
-                                "type": "default"
-                              },
-                              "commonStandardId": {
-                                "def": {
-                                  "type": "optional",
-                                  "innerType": {
-                                    "def": {
-                                      "type": "string"
-                                    },
-                                    "type": "string",
-                                    "format": null,
-                                    "minLength": null,
-                                    "maxLength": null
-                                  }
-                                },
-                                "type": "optional"
                               }
                             }
                           },
@@ -5633,18 +5664,13 @@
                               },
                               "commonStandardId": {
                                 "def": {
-                                  "type": "optional",
-                                  "innerType": {
-                                    "def": {
-                                      "type": "string"
-                                    },
-                                    "type": "string",
-                                    "format": null,
-                                    "minLength": null,
-                                    "maxLength": null
-                                  }
+                                  "type": "literal",
+                                  "values": [
+                                    "host"
+                                  ]
                                 },
-                                "type": "optional"
+                                "type": "literal",
+                                "values": {}
                               }
                             }
                           },
@@ -5658,7 +5684,7 @@
                                 "def": {
                                   "type": "literal",
                                   "values": [
-                                    "selectBox"
+                                    "metadataStandardSearch"
                                   ]
                                 },
                                 "type": "literal",
@@ -5708,18 +5734,147 @@
                                   "type": "default",
                                   "innerType": {
                                     "def": {
-                                      "type": "string"
+                                      "type": "array",
+                                      "element": {
+                                        "def": {
+                                          "type": "object",
+                                          "shape": {
+                                            "metadataStandardId": {
+                                              "def": {
+                                                "type": "default",
+                                                "innerType": {
+                                                  "def": {
+                                                    "type": "string"
+                                                  },
+                                                  "type": "string",
+                                                  "format": null,
+                                                  "minLength": null,
+                                                  "maxLength": null
+                                                },
+                                                "defaultValue": ""
+                                              },
+                                              "type": "default"
+                                            },
+                                            "metadataStandardName": {
+                                              "def": {
+                                                "type": "default",
+                                                "innerType": {
+                                                  "def": {
+                                                    "type": "string"
+                                                  },
+                                                  "type": "string",
+                                                  "format": null,
+                                                  "minLength": null,
+                                                  "maxLength": null
+                                                },
+                                                "defaultValue": ""
+                                              },
+                                              "type": "default"
+                                            }
+                                          }
+                                        },
+                                        "type": "object"
+                                      }
                                     },
-                                    "type": "string",
-                                    "format": null,
-                                    "minLength": null,
-                                    "maxLength": null
+                                    "type": "array",
+                                    "element": {
+                                      "def": {
+                                        "type": "object",
+                                        "shape": {
+                                          "metadataStandardId": {
+                                            "def": {
+                                              "type": "default",
+                                              "innerType": {
+                                                "def": {
+                                                  "type": "string"
+                                                },
+                                                "type": "string",
+                                                "format": null,
+                                                "minLength": null,
+                                                "maxLength": null
+                                              },
+                                              "defaultValue": ""
+                                            },
+                                            "type": "default"
+                                          },
+                                          "metadataStandardName": {
+                                            "def": {
+                                              "type": "default",
+                                              "innerType": {
+                                                "def": {
+                                                  "type": "string"
+                                                },
+                                                "type": "string",
+                                                "format": null,
+                                                "minLength": null,
+                                                "maxLength": null
+                                              },
+                                              "defaultValue": ""
+                                            },
+                                            "type": "default"
+                                          }
+                                        }
+                                      },
+                                      "type": "object"
+                                    }
                                   },
-                                  "defaultValue": ""
+                                  "defaultValue": []
                                 },
                                 "type": "default"
                               },
                               "commonStandardId": {
+                                "def": {
+                                  "type": "literal",
+                                  "values": [
+                                    "metadata"
+                                  ]
+                                },
+                                "type": "literal",
+                                "values": {}
+                              }
+                            }
+                          },
+                          "type": "object"
+                        },
+                        {
+                          "def": {
+                            "type": "object",
+                            "shape": {
+                              "type": {
+                                "def": {
+                                  "type": "literal",
+                                  "values": [
+                                    "licenseSearch"
+                                  ]
+                                },
+                                "type": "literal",
+                                "values": {}
+                              },
+                              "meta": {
+                                "def": {
+                                  "type": "object",
+                                  "shape": {
+                                    "schemaVersion": {
+                                      "def": {
+                                        "type": "default",
+                                        "innerType": {
+                                          "def": {
+                                            "type": "string"
+                                          },
+                                          "type": "string",
+                                          "format": null,
+                                          "minLength": null,
+                                          "maxLength": null
+                                        },
+                                        "defaultValue": "1.0"
+                                      },
+                                      "type": "default"
+                                    }
+                                  }
+                                },
+                                "type": "object"
+                              },
+                              "comment": {
                                 "def": {
                                   "type": "optional",
                                   "innerType": {
@@ -5733,6 +5888,109 @@
                                   }
                                 },
                                 "type": "optional"
+                              },
+                              "answer": {
+                                "def": {
+                                  "type": "default",
+                                  "innerType": {
+                                    "def": {
+                                      "type": "array",
+                                      "element": {
+                                        "def": {
+                                          "type": "object",
+                                          "shape": {
+                                            "licenseId": {
+                                              "def": {
+                                                "type": "default",
+                                                "innerType": {
+                                                  "def": {
+                                                    "type": "string"
+                                                  },
+                                                  "type": "string",
+                                                  "format": null,
+                                                  "minLength": null,
+                                                  "maxLength": null
+                                                },
+                                                "defaultValue": ""
+                                              },
+                                              "type": "default"
+                                            },
+                                            "licenseName": {
+                                              "def": {
+                                                "type": "default",
+                                                "innerType": {
+                                                  "def": {
+                                                    "type": "string"
+                                                  },
+                                                  "type": "string",
+                                                  "format": null,
+                                                  "minLength": null,
+                                                  "maxLength": null
+                                                },
+                                                "defaultValue": ""
+                                              },
+                                              "type": "default"
+                                            }
+                                          }
+                                        },
+                                        "type": "object"
+                                      }
+                                    },
+                                    "type": "array",
+                                    "element": {
+                                      "def": {
+                                        "type": "object",
+                                        "shape": {
+                                          "licenseId": {
+                                            "def": {
+                                              "type": "default",
+                                              "innerType": {
+                                                "def": {
+                                                  "type": "string"
+                                                },
+                                                "type": "string",
+                                                "format": null,
+                                                "minLength": null,
+                                                "maxLength": null
+                                              },
+                                              "defaultValue": ""
+                                            },
+                                            "type": "default"
+                                          },
+                                          "licenseName": {
+                                            "def": {
+                                              "type": "default",
+                                              "innerType": {
+                                                "def": {
+                                                  "type": "string"
+                                                },
+                                                "type": "string",
+                                                "format": null,
+                                                "minLength": null,
+                                                "maxLength": null
+                                              },
+                                              "defaultValue": ""
+                                            },
+                                            "type": "default"
+                                          }
+                                        }
+                                      },
+                                      "type": "object"
+                                    }
+                                  },
+                                  "defaultValue": []
+                                },
+                                "type": "default"
+                              },
+                              "commonStandardId": {
+                                "def": {
+                                  "type": "literal",
+                                  "values": [
+                                    "license_ref"
+                                  ]
+                                },
+                                "type": "literal",
+                                "values": {}
                               }
                             }
                           },
@@ -5809,117 +6067,273 @@
                               },
                               "commonStandardId": {
                                 "def": {
-                                  "type": "optional",
-                                  "innerType": {
-                                    "def": {
-                                      "type": "string"
-                                    },
-                                    "type": "string",
-                                    "format": null,
-                                    "minLength": null,
-                                    "maxLength": null
-                                  }
-                                },
-                                "type": "optional"
-                              }
-                            }
-                          },
-                          "type": "object"
-                        },
-                        {
-                          "def": {
-                            "type": "object",
-                            "shape": {
-                              "type": {
-                                "def": {
                                   "type": "literal",
                                   "values": [
-                                    "textArea"
+                                    "custom"
                                   ]
                                 },
                                 "type": "literal",
                                 "values": {}
-                              },
-                              "meta": {
-                                "def": {
-                                  "type": "object",
-                                  "shape": {
-                                    "schemaVersion": {
-                                      "def": {
-                                        "type": "default",
-                                        "innerType": {
-                                          "def": {
-                                            "type": "string"
-                                          },
-                                          "type": "string",
-                                          "format": null,
-                                          "minLength": null,
-                                          "maxLength": null
-                                        },
-                                        "defaultValue": "1.0"
-                                      },
-                                      "type": "default"
-                                    }
-                                  }
-                                },
-                                "type": "object"
-                              },
-                              "comment": {
-                                "def": {
-                                  "type": "optional",
-                                  "innerType": {
-                                    "def": {
-                                      "type": "string"
-                                    },
-                                    "type": "string",
-                                    "format": null,
-                                    "minLength": null,
-                                    "maxLength": null
-                                  }
-                                },
-                                "type": "optional"
-                              },
-                              "answer": {
-                                "def": {
-                                  "type": "default",
-                                  "innerType": {
-                                    "def": {
-                                      "type": "string"
-                                    },
-                                    "type": "string",
-                                    "format": null,
-                                    "minLength": null,
-                                    "maxLength": null
-                                  },
-                                  "defaultValue": ""
-                                },
-                                "type": "default"
-                              },
-                              "commonStandardId": {
-                                "def": {
-                                  "type": "optional",
-                                  "innerType": {
-                                    "def": {
-                                      "type": "string"
-                                    },
-                                    "type": "string",
-                                    "format": null,
-                                    "minLength": null,
-                                    "maxLength": null
-                                  }
-                                },
-                                "type": "optional"
                               }
                             }
                           },
                           "type": "object"
                         }
                       ],
-                      "discriminator": "type",
+                      "discriminator": "commonStandardId",
                       "inclusive": false
                     },
                     "type": "union",
                     "options": [
+                      {
+                        "def": {
+                          "type": "object",
+                          "shape": {
+                            "type": {
+                              "def": {
+                                "type": "literal",
+                                "values": [
+                                  "text"
+                                ]
+                              },
+                              "type": "literal",
+                              "values": {}
+                            },
+                            "meta": {
+                              "def": {
+                                "type": "object",
+                                "shape": {
+                                  "schemaVersion": {
+                                    "def": {
+                                      "type": "default",
+                                      "innerType": {
+                                        "def": {
+                                          "type": "string"
+                                        },
+                                        "type": "string",
+                                        "format": null,
+                                        "minLength": null,
+                                        "maxLength": null
+                                      },
+                                      "defaultValue": "1.0"
+                                    },
+                                    "type": "default"
+                                  }
+                                }
+                              },
+                              "type": "object"
+                            },
+                            "comment": {
+                              "def": {
+                                "type": "optional",
+                                "innerType": {
+                                  "def": {
+                                    "type": "string"
+                                  },
+                                  "type": "string",
+                                  "format": null,
+                                  "minLength": null,
+                                  "maxLength": null
+                                }
+                              },
+                              "type": "optional"
+                            },
+                            "answer": {
+                              "def": {
+                                "type": "default",
+                                "innerType": {
+                                  "def": {
+                                    "type": "string"
+                                  },
+                                  "type": "string",
+                                  "format": null,
+                                  "minLength": null,
+                                  "maxLength": null
+                                },
+                                "defaultValue": ""
+                              },
+                              "type": "default"
+                            },
+                            "commonStandardId": {
+                              "def": {
+                                "type": "literal",
+                                "values": [
+                                  "title"
+                                ]
+                              },
+                              "type": "literal",
+                              "values": {}
+                            }
+                          }
+                        },
+                        "type": "object"
+                      },
+                      {
+                        "def": {
+                          "type": "object",
+                          "shape": {
+                            "type": {
+                              "def": {
+                                "type": "literal",
+                                "values": [
+                                  "textArea"
+                                ]
+                              },
+                              "type": "literal",
+                              "values": {}
+                            },
+                            "meta": {
+                              "def": {
+                                "type": "object",
+                                "shape": {
+                                  "schemaVersion": {
+                                    "def": {
+                                      "type": "default",
+                                      "innerType": {
+                                        "def": {
+                                          "type": "string"
+                                        },
+                                        "type": "string",
+                                        "format": null,
+                                        "minLength": null,
+                                        "maxLength": null
+                                      },
+                                      "defaultValue": "1.0"
+                                    },
+                                    "type": "default"
+                                  }
+                                }
+                              },
+                              "type": "object"
+                            },
+                            "comment": {
+                              "def": {
+                                "type": "optional",
+                                "innerType": {
+                                  "def": {
+                                    "type": "string"
+                                  },
+                                  "type": "string",
+                                  "format": null,
+                                  "minLength": null,
+                                  "maxLength": null
+                                }
+                              },
+                              "type": "optional"
+                            },
+                            "answer": {
+                              "def": {
+                                "type": "default",
+                                "innerType": {
+                                  "def": {
+                                    "type": "string"
+                                  },
+                                  "type": "string",
+                                  "format": null,
+                                  "minLength": null,
+                                  "maxLength": null
+                                },
+                                "defaultValue": ""
+                              },
+                              "type": "default"
+                            },
+                            "commonStandardId": {
+                              "def": {
+                                "type": "literal",
+                                "values": [
+                                  "description"
+                                ]
+                              },
+                              "type": "literal",
+                              "values": {}
+                            }
+                          }
+                        },
+                        "type": "object"
+                      },
+                      {
+                        "def": {
+                          "type": "object",
+                          "shape": {
+                            "type": {
+                              "def": {
+                                "type": "literal",
+                                "values": [
+                                  "selectBox"
+                                ]
+                              },
+                              "type": "literal",
+                              "values": {}
+                            },
+                            "meta": {
+                              "def": {
+                                "type": "object",
+                                "shape": {
+                                  "schemaVersion": {
+                                    "def": {
+                                      "type": "default",
+                                      "innerType": {
+                                        "def": {
+                                          "type": "string"
+                                        },
+                                        "type": "string",
+                                        "format": null,
+                                        "minLength": null,
+                                        "maxLength": null
+                                      },
+                                      "defaultValue": "1.0"
+                                    },
+                                    "type": "default"
+                                  }
+                                }
+                              },
+                              "type": "object"
+                            },
+                            "comment": {
+                              "def": {
+                                "type": "optional",
+                                "innerType": {
+                                  "def": {
+                                    "type": "string"
+                                  },
+                                  "type": "string",
+                                  "format": null,
+                                  "minLength": null,
+                                  "maxLength": null
+                                }
+                              },
+                              "type": "optional"
+                            },
+                            "answer": {
+                              "def": {
+                                "type": "default",
+                                "innerType": {
+                                  "def": {
+                                    "type": "string"
+                                  },
+                                  "type": "string",
+                                  "format": null,
+                                  "minLength": null,
+                                  "maxLength": null
+                                },
+                                "defaultValue": ""
+                              },
+                              "type": "default"
+                            },
+                            "commonStandardId": {
+                              "def": {
+                                "type": "literal",
+                                "values": [
+                                  "type"
+                                ]
+                              },
+                              "type": "literal",
+                              "values": {}
+                            }
+                          }
+                        },
+                        "type": "object"
+                      },
                       {
                         "def": {
                           "type": "object",
@@ -6008,6 +6422,58 @@
                             },
                             "commonStandardId": {
                               "def": {
+                                "type": "literal",
+                                "values": [
+                                  "data_flags"
+                                ]
+                              },
+                              "type": "literal",
+                              "values": {}
+                            }
+                          }
+                        },
+                        "type": "object"
+                      },
+                      {
+                        "def": {
+                          "type": "object",
+                          "shape": {
+                            "type": {
+                              "def": {
+                                "type": "literal",
+                                "values": [
+                                  "radioButtons"
+                                ]
+                              },
+                              "type": "literal",
+                              "values": {}
+                            },
+                            "meta": {
+                              "def": {
+                                "type": "object",
+                                "shape": {
+                                  "schemaVersion": {
+                                    "def": {
+                                      "type": "default",
+                                      "innerType": {
+                                        "def": {
+                                          "type": "string"
+                                        },
+                                        "type": "string",
+                                        "format": null,
+                                        "minLength": null,
+                                        "maxLength": null
+                                      },
+                                      "defaultValue": "1.0"
+                                    },
+                                    "type": "default"
+                                  }
+                                }
+                              },
+                              "type": "object"
+                            },
+                            "comment": {
+                              "def": {
                                 "type": "optional",
                                 "innerType": {
                                   "def": {
@@ -6020,6 +6486,32 @@
                                 }
                               },
                               "type": "optional"
+                            },
+                            "answer": {
+                              "def": {
+                                "type": "default",
+                                "innerType": {
+                                  "def": {
+                                    "type": "string"
+                                  },
+                                  "type": "string",
+                                  "format": null,
+                                  "minLength": null,
+                                  "maxLength": null
+                                },
+                                "defaultValue": ""
+                              },
+                              "type": "default"
+                            },
+                            "commonStandardId": {
+                              "def": {
+                                "type": "literal",
+                                "values": [
+                                  "data_access"
+                                ]
+                              },
+                              "type": "literal",
+                              "values": {}
                             }
                           }
                         },
@@ -6096,348 +6588,13 @@
                             },
                             "commonStandardId": {
                               "def": {
-                                "type": "optional",
-                                "innerType": {
-                                  "def": {
-                                    "type": "string"
-                                  },
-                                  "type": "string",
-                                  "format": null,
-                                  "minLength": null,
-                                  "maxLength": null
-                                }
-                              },
-                              "type": "optional"
-                            }
-                          }
-                        },
-                        "type": "object"
-                      },
-                      {
-                        "def": {
-                          "type": "object",
-                          "shape": {
-                            "type": {
-                              "def": {
                                 "type": "literal",
                                 "values": [
-                                  "licenseSearch"
+                                  "issued"
                                 ]
                               },
                               "type": "literal",
                               "values": {}
-                            },
-                            "meta": {
-                              "def": {
-                                "type": "object",
-                                "shape": {
-                                  "schemaVersion": {
-                                    "def": {
-                                      "type": "default",
-                                      "innerType": {
-                                        "def": {
-                                          "type": "string"
-                                        },
-                                        "type": "string",
-                                        "format": null,
-                                        "minLength": null,
-                                        "maxLength": null
-                                      },
-                                      "defaultValue": "1.0"
-                                    },
-                                    "type": "default"
-                                  }
-                                }
-                              },
-                              "type": "object"
-                            },
-                            "comment": {
-                              "def": {
-                                "type": "optional",
-                                "innerType": {
-                                  "def": {
-                                    "type": "string"
-                                  },
-                                  "type": "string",
-                                  "format": null,
-                                  "minLength": null,
-                                  "maxLength": null
-                                }
-                              },
-                              "type": "optional"
-                            },
-                            "answer": {
-                              "def": {
-                                "type": "default",
-                                "innerType": {
-                                  "def": {
-                                    "type": "array",
-                                    "element": {
-                                      "def": {
-                                        "type": "object",
-                                        "shape": {
-                                          "licenseId": {
-                                            "def": {
-                                              "type": "default",
-                                              "innerType": {
-                                                "def": {
-                                                  "type": "string"
-                                                },
-                                                "type": "string",
-                                                "format": null,
-                                                "minLength": null,
-                                                "maxLength": null
-                                              },
-                                              "defaultValue": ""
-                                            },
-                                            "type": "default"
-                                          },
-                                          "licenseName": {
-                                            "def": {
-                                              "type": "default",
-                                              "innerType": {
-                                                "def": {
-                                                  "type": "string"
-                                                },
-                                                "type": "string",
-                                                "format": null,
-                                                "minLength": null,
-                                                "maxLength": null
-                                              },
-                                              "defaultValue": ""
-                                            },
-                                            "type": "default"
-                                          }
-                                        }
-                                      },
-                                      "type": "object"
-                                    }
-                                  },
-                                  "type": "array",
-                                  "element": {
-                                    "def": {
-                                      "type": "object",
-                                      "shape": {
-                                        "licenseId": {
-                                          "def": {
-                                            "type": "default",
-                                            "innerType": {
-                                              "def": {
-                                                "type": "string"
-                                              },
-                                              "type": "string",
-                                              "format": null,
-                                              "minLength": null,
-                                              "maxLength": null
-                                            },
-                                            "defaultValue": ""
-                                          },
-                                          "type": "default"
-                                        },
-                                        "licenseName": {
-                                          "def": {
-                                            "type": "default",
-                                            "innerType": {
-                                              "def": {
-                                                "type": "string"
-                                              },
-                                              "type": "string",
-                                              "format": null,
-                                              "minLength": null,
-                                              "maxLength": null
-                                            },
-                                            "defaultValue": ""
-                                          },
-                                          "type": "default"
-                                        }
-                                      }
-                                    },
-                                    "type": "object"
-                                  }
-                                },
-                                "defaultValue": []
-                              },
-                              "type": "default"
-                            },
-                            "commonStandardId": {
-                              "def": {
-                                "type": "optional",
-                                "innerType": {
-                                  "def": {
-                                    "type": "string"
-                                  },
-                                  "type": "string",
-                                  "format": null,
-                                  "minLength": null,
-                                  "maxLength": null
-                                }
-                              },
-                              "type": "optional"
-                            }
-                          }
-                        },
-                        "type": "object"
-                      },
-                      {
-                        "def": {
-                          "type": "object",
-                          "shape": {
-                            "type": {
-                              "def": {
-                                "type": "literal",
-                                "values": [
-                                  "metadataStandardSearch"
-                                ]
-                              },
-                              "type": "literal",
-                              "values": {}
-                            },
-                            "meta": {
-                              "def": {
-                                "type": "object",
-                                "shape": {
-                                  "schemaVersion": {
-                                    "def": {
-                                      "type": "default",
-                                      "innerType": {
-                                        "def": {
-                                          "type": "string"
-                                        },
-                                        "type": "string",
-                                        "format": null,
-                                        "minLength": null,
-                                        "maxLength": null
-                                      },
-                                      "defaultValue": "1.0"
-                                    },
-                                    "type": "default"
-                                  }
-                                }
-                              },
-                              "type": "object"
-                            },
-                            "comment": {
-                              "def": {
-                                "type": "optional",
-                                "innerType": {
-                                  "def": {
-                                    "type": "string"
-                                  },
-                                  "type": "string",
-                                  "format": null,
-                                  "minLength": null,
-                                  "maxLength": null
-                                }
-                              },
-                              "type": "optional"
-                            },
-                            "answer": {
-                              "def": {
-                                "type": "default",
-                                "innerType": {
-                                  "def": {
-                                    "type": "array",
-                                    "element": {
-                                      "def": {
-                                        "type": "object",
-                                        "shape": {
-                                          "metadataStandardId": {
-                                            "def": {
-                                              "type": "default",
-                                              "innerType": {
-                                                "def": {
-                                                  "type": "string"
-                                                },
-                                                "type": "string",
-                                                "format": null,
-                                                "minLength": null,
-                                                "maxLength": null
-                                              },
-                                              "defaultValue": ""
-                                            },
-                                            "type": "default"
-                                          },
-                                          "metadataStandardName": {
-                                            "def": {
-                                              "type": "default",
-                                              "innerType": {
-                                                "def": {
-                                                  "type": "string"
-                                                },
-                                                "type": "string",
-                                                "format": null,
-                                                "minLength": null,
-                                                "maxLength": null
-                                              },
-                                              "defaultValue": ""
-                                            },
-                                            "type": "default"
-                                          }
-                                        }
-                                      },
-                                      "type": "object"
-                                    }
-                                  },
-                                  "type": "array",
-                                  "element": {
-                                    "def": {
-                                      "type": "object",
-                                      "shape": {
-                                        "metadataStandardId": {
-                                          "def": {
-                                            "type": "default",
-                                            "innerType": {
-                                              "def": {
-                                                "type": "string"
-                                              },
-                                              "type": "string",
-                                              "format": null,
-                                              "minLength": null,
-                                              "maxLength": null
-                                            },
-                                            "defaultValue": ""
-                                          },
-                                          "type": "default"
-                                        },
-                                        "metadataStandardName": {
-                                          "def": {
-                                            "type": "default",
-                                            "innerType": {
-                                              "def": {
-                                                "type": "string"
-                                              },
-                                              "type": "string",
-                                              "format": null,
-                                              "minLength": null,
-                                              "maxLength": null
-                                            },
-                                            "defaultValue": ""
-                                          },
-                                          "type": "default"
-                                        }
-                                      }
-                                    },
-                                    "type": "object"
-                                  }
-                                },
-                                "defaultValue": []
-                              },
-                              "type": "default"
-                            },
-                            "commonStandardId": {
-                              "def": {
-                                "type": "optional",
-                                "innerType": {
-                                  "def": {
-                                    "type": "string"
-                                  },
-                                  "type": "string",
-                                  "format": null,
-                                  "minLength": null,
-                                  "maxLength": null
-                                }
-                              },
-                              "type": "optional"
                             }
                           }
                         },
@@ -6541,106 +6698,13 @@
                             },
                             "commonStandardId": {
                               "def": {
-                                "type": "optional",
-                                "innerType": {
-                                  "def": {
-                                    "type": "string"
-                                  },
-                                  "type": "string",
-                                  "format": null,
-                                  "minLength": null,
-                                  "maxLength": null
-                                }
-                              },
-                              "type": "optional"
-                            }
-                          }
-                        },
-                        "type": "object"
-                      },
-                      {
-                        "def": {
-                          "type": "object",
-                          "shape": {
-                            "type": {
-                              "def": {
                                 "type": "literal",
                                 "values": [
-                                  "radioButtons"
+                                  "byte_size"
                                 ]
                               },
                               "type": "literal",
                               "values": {}
-                            },
-                            "meta": {
-                              "def": {
-                                "type": "object",
-                                "shape": {
-                                  "schemaVersion": {
-                                    "def": {
-                                      "type": "default",
-                                      "innerType": {
-                                        "def": {
-                                          "type": "string"
-                                        },
-                                        "type": "string",
-                                        "format": null,
-                                        "minLength": null,
-                                        "maxLength": null
-                                      },
-                                      "defaultValue": "1.0"
-                                    },
-                                    "type": "default"
-                                  }
-                                }
-                              },
-                              "type": "object"
-                            },
-                            "comment": {
-                              "def": {
-                                "type": "optional",
-                                "innerType": {
-                                  "def": {
-                                    "type": "string"
-                                  },
-                                  "type": "string",
-                                  "format": null,
-                                  "minLength": null,
-                                  "maxLength": null
-                                }
-                              },
-                              "type": "optional"
-                            },
-                            "answer": {
-                              "def": {
-                                "type": "default",
-                                "innerType": {
-                                  "def": {
-                                    "type": "string"
-                                  },
-                                  "type": "string",
-                                  "format": null,
-                                  "minLength": null,
-                                  "maxLength": null
-                                },
-                                "defaultValue": ""
-                              },
-                              "type": "default"
-                            },
-                            "commonStandardId": {
-                              "def": {
-                                "type": "optional",
-                                "innerType": {
-                                  "def": {
-                                    "type": "string"
-                                  },
-                                  "type": "string",
-                                  "format": null,
-                                  "minLength": null,
-                                  "maxLength": null
-                                }
-                              },
-                              "type": "optional"
                             }
                           }
                         },
@@ -6794,18 +6858,13 @@
                             },
                             "commonStandardId": {
                               "def": {
-                                "type": "optional",
-                                "innerType": {
-                                  "def": {
-                                    "type": "string"
-                                  },
-                                  "type": "string",
-                                  "format": null,
-                                  "minLength": null,
-                                  "maxLength": null
-                                }
+                                "type": "literal",
+                                "values": [
+                                  "host"
+                                ]
                               },
-                              "type": "optional"
+                              "type": "literal",
+                              "values": {}
                             }
                           }
                         },
@@ -6819,7 +6878,7 @@
                               "def": {
                                 "type": "literal",
                                 "values": [
-                                  "selectBox"
+                                  "metadataStandardSearch"
                                 ]
                               },
                               "type": "literal",
@@ -6869,18 +6928,147 @@
                                 "type": "default",
                                 "innerType": {
                                   "def": {
-                                    "type": "string"
+                                    "type": "array",
+                                    "element": {
+                                      "def": {
+                                        "type": "object",
+                                        "shape": {
+                                          "metadataStandardId": {
+                                            "def": {
+                                              "type": "default",
+                                              "innerType": {
+                                                "def": {
+                                                  "type": "string"
+                                                },
+                                                "type": "string",
+                                                "format": null,
+                                                "minLength": null,
+                                                "maxLength": null
+                                              },
+                                              "defaultValue": ""
+                                            },
+                                            "type": "default"
+                                          },
+                                          "metadataStandardName": {
+                                            "def": {
+                                              "type": "default",
+                                              "innerType": {
+                                                "def": {
+                                                  "type": "string"
+                                                },
+                                                "type": "string",
+                                                "format": null,
+                                                "minLength": null,
+                                                "maxLength": null
+                                              },
+                                              "defaultValue": ""
+                                            },
+                                            "type": "default"
+                                          }
+                                        }
+                                      },
+                                      "type": "object"
+                                    }
                                   },
-                                  "type": "string",
-                                  "format": null,
-                                  "minLength": null,
-                                  "maxLength": null
+                                  "type": "array",
+                                  "element": {
+                                    "def": {
+                                      "type": "object",
+                                      "shape": {
+                                        "metadataStandardId": {
+                                          "def": {
+                                            "type": "default",
+                                            "innerType": {
+                                              "def": {
+                                                "type": "string"
+                                              },
+                                              "type": "string",
+                                              "format": null,
+                                              "minLength": null,
+                                              "maxLength": null
+                                            },
+                                            "defaultValue": ""
+                                          },
+                                          "type": "default"
+                                        },
+                                        "metadataStandardName": {
+                                          "def": {
+                                            "type": "default",
+                                            "innerType": {
+                                              "def": {
+                                                "type": "string"
+                                              },
+                                              "type": "string",
+                                              "format": null,
+                                              "minLength": null,
+                                              "maxLength": null
+                                            },
+                                            "defaultValue": ""
+                                          },
+                                          "type": "default"
+                                        }
+                                      }
+                                    },
+                                    "type": "object"
+                                  }
                                 },
-                                "defaultValue": ""
+                                "defaultValue": []
                               },
                               "type": "default"
                             },
                             "commonStandardId": {
+                              "def": {
+                                "type": "literal",
+                                "values": [
+                                  "metadata"
+                                ]
+                              },
+                              "type": "literal",
+                              "values": {}
+                            }
+                          }
+                        },
+                        "type": "object"
+                      },
+                      {
+                        "def": {
+                          "type": "object",
+                          "shape": {
+                            "type": {
+                              "def": {
+                                "type": "literal",
+                                "values": [
+                                  "licenseSearch"
+                                ]
+                              },
+                              "type": "literal",
+                              "values": {}
+                            },
+                            "meta": {
+                              "def": {
+                                "type": "object",
+                                "shape": {
+                                  "schemaVersion": {
+                                    "def": {
+                                      "type": "default",
+                                      "innerType": {
+                                        "def": {
+                                          "type": "string"
+                                        },
+                                        "type": "string",
+                                        "format": null,
+                                        "minLength": null,
+                                        "maxLength": null
+                                      },
+                                      "defaultValue": "1.0"
+                                    },
+                                    "type": "default"
+                                  }
+                                }
+                              },
+                              "type": "object"
+                            },
+                            "comment": {
                               "def": {
                                 "type": "optional",
                                 "innerType": {
@@ -6894,6 +7082,109 @@
                                 }
                               },
                               "type": "optional"
+                            },
+                            "answer": {
+                              "def": {
+                                "type": "default",
+                                "innerType": {
+                                  "def": {
+                                    "type": "array",
+                                    "element": {
+                                      "def": {
+                                        "type": "object",
+                                        "shape": {
+                                          "licenseId": {
+                                            "def": {
+                                              "type": "default",
+                                              "innerType": {
+                                                "def": {
+                                                  "type": "string"
+                                                },
+                                                "type": "string",
+                                                "format": null,
+                                                "minLength": null,
+                                                "maxLength": null
+                                              },
+                                              "defaultValue": ""
+                                            },
+                                            "type": "default"
+                                          },
+                                          "licenseName": {
+                                            "def": {
+                                              "type": "default",
+                                              "innerType": {
+                                                "def": {
+                                                  "type": "string"
+                                                },
+                                                "type": "string",
+                                                "format": null,
+                                                "minLength": null,
+                                                "maxLength": null
+                                              },
+                                              "defaultValue": ""
+                                            },
+                                            "type": "default"
+                                          }
+                                        }
+                                      },
+                                      "type": "object"
+                                    }
+                                  },
+                                  "type": "array",
+                                  "element": {
+                                    "def": {
+                                      "type": "object",
+                                      "shape": {
+                                        "licenseId": {
+                                          "def": {
+                                            "type": "default",
+                                            "innerType": {
+                                              "def": {
+                                                "type": "string"
+                                              },
+                                              "type": "string",
+                                              "format": null,
+                                              "minLength": null,
+                                              "maxLength": null
+                                            },
+                                            "defaultValue": ""
+                                          },
+                                          "type": "default"
+                                        },
+                                        "licenseName": {
+                                          "def": {
+                                            "type": "default",
+                                            "innerType": {
+                                              "def": {
+                                                "type": "string"
+                                              },
+                                              "type": "string",
+                                              "format": null,
+                                              "minLength": null,
+                                              "maxLength": null
+                                            },
+                                            "defaultValue": ""
+                                          },
+                                          "type": "default"
+                                        }
+                                      }
+                                    },
+                                    "type": "object"
+                                  }
+                                },
+                                "defaultValue": []
+                              },
+                              "type": "default"
+                            },
+                            "commonStandardId": {
+                              "def": {
+                                "type": "literal",
+                                "values": [
+                                  "license_ref"
+                                ]
+                              },
+                              "type": "literal",
+                              "values": {}
                             }
                           }
                         },
@@ -6970,106 +7261,13 @@
                             },
                             "commonStandardId": {
                               "def": {
-                                "type": "optional",
-                                "innerType": {
-                                  "def": {
-                                    "type": "string"
-                                  },
-                                  "type": "string",
-                                  "format": null,
-                                  "minLength": null,
-                                  "maxLength": null
-                                }
-                              },
-                              "type": "optional"
-                            }
-                          }
-                        },
-                        "type": "object"
-                      },
-                      {
-                        "def": {
-                          "type": "object",
-                          "shape": {
-                            "type": {
-                              "def": {
                                 "type": "literal",
                                 "values": [
-                                  "textArea"
+                                  "custom"
                                 ]
                               },
                               "type": "literal",
                               "values": {}
-                            },
-                            "meta": {
-                              "def": {
-                                "type": "object",
-                                "shape": {
-                                  "schemaVersion": {
-                                    "def": {
-                                      "type": "default",
-                                      "innerType": {
-                                        "def": {
-                                          "type": "string"
-                                        },
-                                        "type": "string",
-                                        "format": null,
-                                        "minLength": null,
-                                        "maxLength": null
-                                      },
-                                      "defaultValue": "1.0"
-                                    },
-                                    "type": "default"
-                                  }
-                                }
-                              },
-                              "type": "object"
-                            },
-                            "comment": {
-                              "def": {
-                                "type": "optional",
-                                "innerType": {
-                                  "def": {
-                                    "type": "string"
-                                  },
-                                  "type": "string",
-                                  "format": null,
-                                  "minLength": null,
-                                  "maxLength": null
-                                }
-                              },
-                              "type": "optional"
-                            },
-                            "answer": {
-                              "def": {
-                                "type": "default",
-                                "innerType": {
-                                  "def": {
-                                    "type": "string"
-                                  },
-                                  "type": "string",
-                                  "format": null,
-                                  "minLength": null,
-                                  "maxLength": null
-                                },
-                                "defaultValue": ""
-                              },
-                              "type": "default"
-                            },
-                            "commonStandardId": {
-                              "def": {
-                                "type": "optional",
-                                "innerType": {
-                                  "def": {
-                                    "type": "string"
-                                  },
-                                  "type": "string",
-                                  "format": null,
-                                  "minLength": null,
-                                  "maxLength": null
-                                }
-                              },
-                              "type": "optional"
                             }
                           }
                         },
@@ -7091,6 +7289,255 @@
                               "def": {
                                 "type": "literal",
                                 "values": [
+                                  "text"
+                                ]
+                              },
+                              "type": "literal",
+                              "values": {}
+                            },
+                            "meta": {
+                              "def": {
+                                "type": "object",
+                                "shape": {
+                                  "schemaVersion": {
+                                    "def": {
+                                      "type": "default",
+                                      "innerType": {
+                                        "def": {
+                                          "type": "string"
+                                        },
+                                        "type": "string",
+                                        "format": null,
+                                        "minLength": null,
+                                        "maxLength": null
+                                      },
+                                      "defaultValue": "1.0"
+                                    },
+                                    "type": "default"
+                                  }
+                                }
+                              },
+                              "type": "object"
+                            },
+                            "comment": {
+                              "def": {
+                                "type": "optional",
+                                "innerType": {
+                                  "def": {
+                                    "type": "string"
+                                  },
+                                  "type": "string",
+                                  "format": null,
+                                  "minLength": null,
+                                  "maxLength": null
+                                }
+                              },
+                              "type": "optional"
+                            },
+                            "answer": {
+                              "def": {
+                                "type": "default",
+                                "innerType": {
+                                  "def": {
+                                    "type": "string"
+                                  },
+                                  "type": "string",
+                                  "format": null,
+                                  "minLength": null,
+                                  "maxLength": null
+                                },
+                                "defaultValue": ""
+                              },
+                              "type": "default"
+                            },
+                            "commonStandardId": {
+                              "def": {
+                                "type": "literal",
+                                "values": [
+                                  "title"
+                                ]
+                              },
+                              "type": "literal",
+                              "values": {}
+                            }
+                          }
+                        },
+                        "type": "object"
+                      },
+                      {
+                        "def": {
+                          "type": "object",
+                          "shape": {
+                            "type": {
+                              "def": {
+                                "type": "literal",
+                                "values": [
+                                  "textArea"
+                                ]
+                              },
+                              "type": "literal",
+                              "values": {}
+                            },
+                            "meta": {
+                              "def": {
+                                "type": "object",
+                                "shape": {
+                                  "schemaVersion": {
+                                    "def": {
+                                      "type": "default",
+                                      "innerType": {
+                                        "def": {
+                                          "type": "string"
+                                        },
+                                        "type": "string",
+                                        "format": null,
+                                        "minLength": null,
+                                        "maxLength": null
+                                      },
+                                      "defaultValue": "1.0"
+                                    },
+                                    "type": "default"
+                                  }
+                                }
+                              },
+                              "type": "object"
+                            },
+                            "comment": {
+                              "def": {
+                                "type": "optional",
+                                "innerType": {
+                                  "def": {
+                                    "type": "string"
+                                  },
+                                  "type": "string",
+                                  "format": null,
+                                  "minLength": null,
+                                  "maxLength": null
+                                }
+                              },
+                              "type": "optional"
+                            },
+                            "answer": {
+                              "def": {
+                                "type": "default",
+                                "innerType": {
+                                  "def": {
+                                    "type": "string"
+                                  },
+                                  "type": "string",
+                                  "format": null,
+                                  "minLength": null,
+                                  "maxLength": null
+                                },
+                                "defaultValue": ""
+                              },
+                              "type": "default"
+                            },
+                            "commonStandardId": {
+                              "def": {
+                                "type": "literal",
+                                "values": [
+                                  "description"
+                                ]
+                              },
+                              "type": "literal",
+                              "values": {}
+                            }
+                          }
+                        },
+                        "type": "object"
+                      },
+                      {
+                        "def": {
+                          "type": "object",
+                          "shape": {
+                            "type": {
+                              "def": {
+                                "type": "literal",
+                                "values": [
+                                  "selectBox"
+                                ]
+                              },
+                              "type": "literal",
+                              "values": {}
+                            },
+                            "meta": {
+                              "def": {
+                                "type": "object",
+                                "shape": {
+                                  "schemaVersion": {
+                                    "def": {
+                                      "type": "default",
+                                      "innerType": {
+                                        "def": {
+                                          "type": "string"
+                                        },
+                                        "type": "string",
+                                        "format": null,
+                                        "minLength": null,
+                                        "maxLength": null
+                                      },
+                                      "defaultValue": "1.0"
+                                    },
+                                    "type": "default"
+                                  }
+                                }
+                              },
+                              "type": "object"
+                            },
+                            "comment": {
+                              "def": {
+                                "type": "optional",
+                                "innerType": {
+                                  "def": {
+                                    "type": "string"
+                                  },
+                                  "type": "string",
+                                  "format": null,
+                                  "minLength": null,
+                                  "maxLength": null
+                                }
+                              },
+                              "type": "optional"
+                            },
+                            "answer": {
+                              "def": {
+                                "type": "default",
+                                "innerType": {
+                                  "def": {
+                                    "type": "string"
+                                  },
+                                  "type": "string",
+                                  "format": null,
+                                  "minLength": null,
+                                  "maxLength": null
+                                },
+                                "defaultValue": ""
+                              },
+                              "type": "default"
+                            },
+                            "commonStandardId": {
+                              "def": {
+                                "type": "literal",
+                                "values": [
+                                  "type"
+                                ]
+                              },
+                              "type": "literal",
+                              "values": {}
+                            }
+                          }
+                        },
+                        "type": "object"
+                      },
+                      {
+                        "def": {
+                          "type": "object",
+                          "shape": {
+                            "type": {
+                              "def": {
+                                "type": "literal",
+                                "values": [
                                   "checkBoxes"
                                 ]
                               },
@@ -7171,6 +7618,58 @@
                             },
                             "commonStandardId": {
                               "def": {
+                                "type": "literal",
+                                "values": [
+                                  "data_flags"
+                                ]
+                              },
+                              "type": "literal",
+                              "values": {}
+                            }
+                          }
+                        },
+                        "type": "object"
+                      },
+                      {
+                        "def": {
+                          "type": "object",
+                          "shape": {
+                            "type": {
+                              "def": {
+                                "type": "literal",
+                                "values": [
+                                  "radioButtons"
+                                ]
+                              },
+                              "type": "literal",
+                              "values": {}
+                            },
+                            "meta": {
+                              "def": {
+                                "type": "object",
+                                "shape": {
+                                  "schemaVersion": {
+                                    "def": {
+                                      "type": "default",
+                                      "innerType": {
+                                        "def": {
+                                          "type": "string"
+                                        },
+                                        "type": "string",
+                                        "format": null,
+                                        "minLength": null,
+                                        "maxLength": null
+                                      },
+                                      "defaultValue": "1.0"
+                                    },
+                                    "type": "default"
+                                  }
+                                }
+                              },
+                              "type": "object"
+                            },
+                            "comment": {
+                              "def": {
                                 "type": "optional",
                                 "innerType": {
                                   "def": {
@@ -7183,6 +7682,32 @@
                                 }
                               },
                               "type": "optional"
+                            },
+                            "answer": {
+                              "def": {
+                                "type": "default",
+                                "innerType": {
+                                  "def": {
+                                    "type": "string"
+                                  },
+                                  "type": "string",
+                                  "format": null,
+                                  "minLength": null,
+                                  "maxLength": null
+                                },
+                                "defaultValue": ""
+                              },
+                              "type": "default"
+                            },
+                            "commonStandardId": {
+                              "def": {
+                                "type": "literal",
+                                "values": [
+                                  "data_access"
+                                ]
+                              },
+                              "type": "literal",
+                              "values": {}
                             }
                           }
                         },
@@ -7259,348 +7784,13 @@
                             },
                             "commonStandardId": {
                               "def": {
-                                "type": "optional",
-                                "innerType": {
-                                  "def": {
-                                    "type": "string"
-                                  },
-                                  "type": "string",
-                                  "format": null,
-                                  "minLength": null,
-                                  "maxLength": null
-                                }
-                              },
-                              "type": "optional"
-                            }
-                          }
-                        },
-                        "type": "object"
-                      },
-                      {
-                        "def": {
-                          "type": "object",
-                          "shape": {
-                            "type": {
-                              "def": {
                                 "type": "literal",
                                 "values": [
-                                  "licenseSearch"
+                                  "issued"
                                 ]
                               },
                               "type": "literal",
                               "values": {}
-                            },
-                            "meta": {
-                              "def": {
-                                "type": "object",
-                                "shape": {
-                                  "schemaVersion": {
-                                    "def": {
-                                      "type": "default",
-                                      "innerType": {
-                                        "def": {
-                                          "type": "string"
-                                        },
-                                        "type": "string",
-                                        "format": null,
-                                        "minLength": null,
-                                        "maxLength": null
-                                      },
-                                      "defaultValue": "1.0"
-                                    },
-                                    "type": "default"
-                                  }
-                                }
-                              },
-                              "type": "object"
-                            },
-                            "comment": {
-                              "def": {
-                                "type": "optional",
-                                "innerType": {
-                                  "def": {
-                                    "type": "string"
-                                  },
-                                  "type": "string",
-                                  "format": null,
-                                  "minLength": null,
-                                  "maxLength": null
-                                }
-                              },
-                              "type": "optional"
-                            },
-                            "answer": {
-                              "def": {
-                                "type": "default",
-                                "innerType": {
-                                  "def": {
-                                    "type": "array",
-                                    "element": {
-                                      "def": {
-                                        "type": "object",
-                                        "shape": {
-                                          "licenseId": {
-                                            "def": {
-                                              "type": "default",
-                                              "innerType": {
-                                                "def": {
-                                                  "type": "string"
-                                                },
-                                                "type": "string",
-                                                "format": null,
-                                                "minLength": null,
-                                                "maxLength": null
-                                              },
-                                              "defaultValue": ""
-                                            },
-                                            "type": "default"
-                                          },
-                                          "licenseName": {
-                                            "def": {
-                                              "type": "default",
-                                              "innerType": {
-                                                "def": {
-                                                  "type": "string"
-                                                },
-                                                "type": "string",
-                                                "format": null,
-                                                "minLength": null,
-                                                "maxLength": null
-                                              },
-                                              "defaultValue": ""
-                                            },
-                                            "type": "default"
-                                          }
-                                        }
-                                      },
-                                      "type": "object"
-                                    }
-                                  },
-                                  "type": "array",
-                                  "element": {
-                                    "def": {
-                                      "type": "object",
-                                      "shape": {
-                                        "licenseId": {
-                                          "def": {
-                                            "type": "default",
-                                            "innerType": {
-                                              "def": {
-                                                "type": "string"
-                                              },
-                                              "type": "string",
-                                              "format": null,
-                                              "minLength": null,
-                                              "maxLength": null
-                                            },
-                                            "defaultValue": ""
-                                          },
-                                          "type": "default"
-                                        },
-                                        "licenseName": {
-                                          "def": {
-                                            "type": "default",
-                                            "innerType": {
-                                              "def": {
-                                                "type": "string"
-                                              },
-                                              "type": "string",
-                                              "format": null,
-                                              "minLength": null,
-                                              "maxLength": null
-                                            },
-                                            "defaultValue": ""
-                                          },
-                                          "type": "default"
-                                        }
-                                      }
-                                    },
-                                    "type": "object"
-                                  }
-                                },
-                                "defaultValue": []
-                              },
-                              "type": "default"
-                            },
-                            "commonStandardId": {
-                              "def": {
-                                "type": "optional",
-                                "innerType": {
-                                  "def": {
-                                    "type": "string"
-                                  },
-                                  "type": "string",
-                                  "format": null,
-                                  "minLength": null,
-                                  "maxLength": null
-                                }
-                              },
-                              "type": "optional"
-                            }
-                          }
-                        },
-                        "type": "object"
-                      },
-                      {
-                        "def": {
-                          "type": "object",
-                          "shape": {
-                            "type": {
-                              "def": {
-                                "type": "literal",
-                                "values": [
-                                  "metadataStandardSearch"
-                                ]
-                              },
-                              "type": "literal",
-                              "values": {}
-                            },
-                            "meta": {
-                              "def": {
-                                "type": "object",
-                                "shape": {
-                                  "schemaVersion": {
-                                    "def": {
-                                      "type": "default",
-                                      "innerType": {
-                                        "def": {
-                                          "type": "string"
-                                        },
-                                        "type": "string",
-                                        "format": null,
-                                        "minLength": null,
-                                        "maxLength": null
-                                      },
-                                      "defaultValue": "1.0"
-                                    },
-                                    "type": "default"
-                                  }
-                                }
-                              },
-                              "type": "object"
-                            },
-                            "comment": {
-                              "def": {
-                                "type": "optional",
-                                "innerType": {
-                                  "def": {
-                                    "type": "string"
-                                  },
-                                  "type": "string",
-                                  "format": null,
-                                  "minLength": null,
-                                  "maxLength": null
-                                }
-                              },
-                              "type": "optional"
-                            },
-                            "answer": {
-                              "def": {
-                                "type": "default",
-                                "innerType": {
-                                  "def": {
-                                    "type": "array",
-                                    "element": {
-                                      "def": {
-                                        "type": "object",
-                                        "shape": {
-                                          "metadataStandardId": {
-                                            "def": {
-                                              "type": "default",
-                                              "innerType": {
-                                                "def": {
-                                                  "type": "string"
-                                                },
-                                                "type": "string",
-                                                "format": null,
-                                                "minLength": null,
-                                                "maxLength": null
-                                              },
-                                              "defaultValue": ""
-                                            },
-                                            "type": "default"
-                                          },
-                                          "metadataStandardName": {
-                                            "def": {
-                                              "type": "default",
-                                              "innerType": {
-                                                "def": {
-                                                  "type": "string"
-                                                },
-                                                "type": "string",
-                                                "format": null,
-                                                "minLength": null,
-                                                "maxLength": null
-                                              },
-                                              "defaultValue": ""
-                                            },
-                                            "type": "default"
-                                          }
-                                        }
-                                      },
-                                      "type": "object"
-                                    }
-                                  },
-                                  "type": "array",
-                                  "element": {
-                                    "def": {
-                                      "type": "object",
-                                      "shape": {
-                                        "metadataStandardId": {
-                                          "def": {
-                                            "type": "default",
-                                            "innerType": {
-                                              "def": {
-                                                "type": "string"
-                                              },
-                                              "type": "string",
-                                              "format": null,
-                                              "minLength": null,
-                                              "maxLength": null
-                                            },
-                                            "defaultValue": ""
-                                          },
-                                          "type": "default"
-                                        },
-                                        "metadataStandardName": {
-                                          "def": {
-                                            "type": "default",
-                                            "innerType": {
-                                              "def": {
-                                                "type": "string"
-                                              },
-                                              "type": "string",
-                                              "format": null,
-                                              "minLength": null,
-                                              "maxLength": null
-                                            },
-                                            "defaultValue": ""
-                                          },
-                                          "type": "default"
-                                        }
-                                      }
-                                    },
-                                    "type": "object"
-                                  }
-                                },
-                                "defaultValue": []
-                              },
-                              "type": "default"
-                            },
-                            "commonStandardId": {
-                              "def": {
-                                "type": "optional",
-                                "innerType": {
-                                  "def": {
-                                    "type": "string"
-                                  },
-                                  "type": "string",
-                                  "format": null,
-                                  "minLength": null,
-                                  "maxLength": null
-                                }
-                              },
-                              "type": "optional"
                             }
                           }
                         },
@@ -7704,106 +7894,13 @@
                             },
                             "commonStandardId": {
                               "def": {
-                                "type": "optional",
-                                "innerType": {
-                                  "def": {
-                                    "type": "string"
-                                  },
-                                  "type": "string",
-                                  "format": null,
-                                  "minLength": null,
-                                  "maxLength": null
-                                }
-                              },
-                              "type": "optional"
-                            }
-                          }
-                        },
-                        "type": "object"
-                      },
-                      {
-                        "def": {
-                          "type": "object",
-                          "shape": {
-                            "type": {
-                              "def": {
                                 "type": "literal",
                                 "values": [
-                                  "radioButtons"
+                                  "byte_size"
                                 ]
                               },
                               "type": "literal",
                               "values": {}
-                            },
-                            "meta": {
-                              "def": {
-                                "type": "object",
-                                "shape": {
-                                  "schemaVersion": {
-                                    "def": {
-                                      "type": "default",
-                                      "innerType": {
-                                        "def": {
-                                          "type": "string"
-                                        },
-                                        "type": "string",
-                                        "format": null,
-                                        "minLength": null,
-                                        "maxLength": null
-                                      },
-                                      "defaultValue": "1.0"
-                                    },
-                                    "type": "default"
-                                  }
-                                }
-                              },
-                              "type": "object"
-                            },
-                            "comment": {
-                              "def": {
-                                "type": "optional",
-                                "innerType": {
-                                  "def": {
-                                    "type": "string"
-                                  },
-                                  "type": "string",
-                                  "format": null,
-                                  "minLength": null,
-                                  "maxLength": null
-                                }
-                              },
-                              "type": "optional"
-                            },
-                            "answer": {
-                              "def": {
-                                "type": "default",
-                                "innerType": {
-                                  "def": {
-                                    "type": "string"
-                                  },
-                                  "type": "string",
-                                  "format": null,
-                                  "minLength": null,
-                                  "maxLength": null
-                                },
-                                "defaultValue": ""
-                              },
-                              "type": "default"
-                            },
-                            "commonStandardId": {
-                              "def": {
-                                "type": "optional",
-                                "innerType": {
-                                  "def": {
-                                    "type": "string"
-                                  },
-                                  "type": "string",
-                                  "format": null,
-                                  "minLength": null,
-                                  "maxLength": null
-                                }
-                              },
-                              "type": "optional"
                             }
                           }
                         },
@@ -7957,18 +8054,13 @@
                             },
                             "commonStandardId": {
                               "def": {
-                                "type": "optional",
-                                "innerType": {
-                                  "def": {
-                                    "type": "string"
-                                  },
-                                  "type": "string",
-                                  "format": null,
-                                  "minLength": null,
-                                  "maxLength": null
-                                }
+                                "type": "literal",
+                                "values": [
+                                  "host"
+                                ]
                               },
-                              "type": "optional"
+                              "type": "literal",
+                              "values": {}
                             }
                           }
                         },
@@ -7982,7 +8074,7 @@
                               "def": {
                                 "type": "literal",
                                 "values": [
-                                  "selectBox"
+                                  "metadataStandardSearch"
                                 ]
                               },
                               "type": "literal",
@@ -8032,18 +8124,147 @@
                                 "type": "default",
                                 "innerType": {
                                   "def": {
-                                    "type": "string"
+                                    "type": "array",
+                                    "element": {
+                                      "def": {
+                                        "type": "object",
+                                        "shape": {
+                                          "metadataStandardId": {
+                                            "def": {
+                                              "type": "default",
+                                              "innerType": {
+                                                "def": {
+                                                  "type": "string"
+                                                },
+                                                "type": "string",
+                                                "format": null,
+                                                "minLength": null,
+                                                "maxLength": null
+                                              },
+                                              "defaultValue": ""
+                                            },
+                                            "type": "default"
+                                          },
+                                          "metadataStandardName": {
+                                            "def": {
+                                              "type": "default",
+                                              "innerType": {
+                                                "def": {
+                                                  "type": "string"
+                                                },
+                                                "type": "string",
+                                                "format": null,
+                                                "minLength": null,
+                                                "maxLength": null
+                                              },
+                                              "defaultValue": ""
+                                            },
+                                            "type": "default"
+                                          }
+                                        }
+                                      },
+                                      "type": "object"
+                                    }
                                   },
-                                  "type": "string",
-                                  "format": null,
-                                  "minLength": null,
-                                  "maxLength": null
+                                  "type": "array",
+                                  "element": {
+                                    "def": {
+                                      "type": "object",
+                                      "shape": {
+                                        "metadataStandardId": {
+                                          "def": {
+                                            "type": "default",
+                                            "innerType": {
+                                              "def": {
+                                                "type": "string"
+                                              },
+                                              "type": "string",
+                                              "format": null,
+                                              "minLength": null,
+                                              "maxLength": null
+                                            },
+                                            "defaultValue": ""
+                                          },
+                                          "type": "default"
+                                        },
+                                        "metadataStandardName": {
+                                          "def": {
+                                            "type": "default",
+                                            "innerType": {
+                                              "def": {
+                                                "type": "string"
+                                              },
+                                              "type": "string",
+                                              "format": null,
+                                              "minLength": null,
+                                              "maxLength": null
+                                            },
+                                            "defaultValue": ""
+                                          },
+                                          "type": "default"
+                                        }
+                                      }
+                                    },
+                                    "type": "object"
+                                  }
                                 },
-                                "defaultValue": ""
+                                "defaultValue": []
                               },
                               "type": "default"
                             },
                             "commonStandardId": {
+                              "def": {
+                                "type": "literal",
+                                "values": [
+                                  "metadata"
+                                ]
+                              },
+                              "type": "literal",
+                              "values": {}
+                            }
+                          }
+                        },
+                        "type": "object"
+                      },
+                      {
+                        "def": {
+                          "type": "object",
+                          "shape": {
+                            "type": {
+                              "def": {
+                                "type": "literal",
+                                "values": [
+                                  "licenseSearch"
+                                ]
+                              },
+                              "type": "literal",
+                              "values": {}
+                            },
+                            "meta": {
+                              "def": {
+                                "type": "object",
+                                "shape": {
+                                  "schemaVersion": {
+                                    "def": {
+                                      "type": "default",
+                                      "innerType": {
+                                        "def": {
+                                          "type": "string"
+                                        },
+                                        "type": "string",
+                                        "format": null,
+                                        "minLength": null,
+                                        "maxLength": null
+                                      },
+                                      "defaultValue": "1.0"
+                                    },
+                                    "type": "default"
+                                  }
+                                }
+                              },
+                              "type": "object"
+                            },
+                            "comment": {
                               "def": {
                                 "type": "optional",
                                 "innerType": {
@@ -8057,6 +8278,109 @@
                                 }
                               },
                               "type": "optional"
+                            },
+                            "answer": {
+                              "def": {
+                                "type": "default",
+                                "innerType": {
+                                  "def": {
+                                    "type": "array",
+                                    "element": {
+                                      "def": {
+                                        "type": "object",
+                                        "shape": {
+                                          "licenseId": {
+                                            "def": {
+                                              "type": "default",
+                                              "innerType": {
+                                                "def": {
+                                                  "type": "string"
+                                                },
+                                                "type": "string",
+                                                "format": null,
+                                                "minLength": null,
+                                                "maxLength": null
+                                              },
+                                              "defaultValue": ""
+                                            },
+                                            "type": "default"
+                                          },
+                                          "licenseName": {
+                                            "def": {
+                                              "type": "default",
+                                              "innerType": {
+                                                "def": {
+                                                  "type": "string"
+                                                },
+                                                "type": "string",
+                                                "format": null,
+                                                "minLength": null,
+                                                "maxLength": null
+                                              },
+                                              "defaultValue": ""
+                                            },
+                                            "type": "default"
+                                          }
+                                        }
+                                      },
+                                      "type": "object"
+                                    }
+                                  },
+                                  "type": "array",
+                                  "element": {
+                                    "def": {
+                                      "type": "object",
+                                      "shape": {
+                                        "licenseId": {
+                                          "def": {
+                                            "type": "default",
+                                            "innerType": {
+                                              "def": {
+                                                "type": "string"
+                                              },
+                                              "type": "string",
+                                              "format": null,
+                                              "minLength": null,
+                                              "maxLength": null
+                                            },
+                                            "defaultValue": ""
+                                          },
+                                          "type": "default"
+                                        },
+                                        "licenseName": {
+                                          "def": {
+                                            "type": "default",
+                                            "innerType": {
+                                              "def": {
+                                                "type": "string"
+                                              },
+                                              "type": "string",
+                                              "format": null,
+                                              "minLength": null,
+                                              "maxLength": null
+                                            },
+                                            "defaultValue": ""
+                                          },
+                                          "type": "default"
+                                        }
+                                      }
+                                    },
+                                    "type": "object"
+                                  }
+                                },
+                                "defaultValue": []
+                              },
+                              "type": "default"
+                            },
+                            "commonStandardId": {
+                              "def": {
+                                "type": "literal",
+                                "values": [
+                                  "license_ref"
+                                ]
+                              },
+                              "type": "literal",
+                              "values": {}
                             }
                           }
                         },
@@ -8133,117 +8457,273 @@
                             },
                             "commonStandardId": {
                               "def": {
-                                "type": "optional",
-                                "innerType": {
-                                  "def": {
-                                    "type": "string"
-                                  },
-                                  "type": "string",
-                                  "format": null,
-                                  "minLength": null,
-                                  "maxLength": null
-                                }
-                              },
-                              "type": "optional"
-                            }
-                          }
-                        },
-                        "type": "object"
-                      },
-                      {
-                        "def": {
-                          "type": "object",
-                          "shape": {
-                            "type": {
-                              "def": {
                                 "type": "literal",
                                 "values": [
-                                  "textArea"
+                                  "custom"
                                 ]
                               },
                               "type": "literal",
                               "values": {}
-                            },
-                            "meta": {
-                              "def": {
-                                "type": "object",
-                                "shape": {
-                                  "schemaVersion": {
-                                    "def": {
-                                      "type": "default",
-                                      "innerType": {
-                                        "def": {
-                                          "type": "string"
-                                        },
-                                        "type": "string",
-                                        "format": null,
-                                        "minLength": null,
-                                        "maxLength": null
-                                      },
-                                      "defaultValue": "1.0"
-                                    },
-                                    "type": "default"
-                                  }
-                                }
-                              },
-                              "type": "object"
-                            },
-                            "comment": {
-                              "def": {
-                                "type": "optional",
-                                "innerType": {
-                                  "def": {
-                                    "type": "string"
-                                  },
-                                  "type": "string",
-                                  "format": null,
-                                  "minLength": null,
-                                  "maxLength": null
-                                }
-                              },
-                              "type": "optional"
-                            },
-                            "answer": {
-                              "def": {
-                                "type": "default",
-                                "innerType": {
-                                  "def": {
-                                    "type": "string"
-                                  },
-                                  "type": "string",
-                                  "format": null,
-                                  "minLength": null,
-                                  "maxLength": null
-                                },
-                                "defaultValue": ""
-                              },
-                              "type": "default"
-                            },
-                            "commonStandardId": {
-                              "def": {
-                                "type": "optional",
-                                "innerType": {
-                                  "def": {
-                                    "type": "string"
-                                  },
-                                  "type": "string",
-                                  "format": null,
-                                  "minLength": null,
-                                  "maxLength": null
-                                }
-                              },
-                              "type": "optional"
                             }
                           }
                         },
                         "type": "object"
                       }
                     ],
-                    "discriminator": "type",
+                    "discriminator": "commonStandardId",
                     "inclusive": false
                   },
                   "type": "union",
                   "options": [
+                    {
+                      "def": {
+                        "type": "object",
+                        "shape": {
+                          "type": {
+                            "def": {
+                              "type": "literal",
+                              "values": [
+                                "text"
+                              ]
+                            },
+                            "type": "literal",
+                            "values": {}
+                          },
+                          "meta": {
+                            "def": {
+                              "type": "object",
+                              "shape": {
+                                "schemaVersion": {
+                                  "def": {
+                                    "type": "default",
+                                    "innerType": {
+                                      "def": {
+                                        "type": "string"
+                                      },
+                                      "type": "string",
+                                      "format": null,
+                                      "minLength": null,
+                                      "maxLength": null
+                                    },
+                                    "defaultValue": "1.0"
+                                  },
+                                  "type": "default"
+                                }
+                              }
+                            },
+                            "type": "object"
+                          },
+                          "comment": {
+                            "def": {
+                              "type": "optional",
+                              "innerType": {
+                                "def": {
+                                  "type": "string"
+                                },
+                                "type": "string",
+                                "format": null,
+                                "minLength": null,
+                                "maxLength": null
+                              }
+                            },
+                            "type": "optional"
+                          },
+                          "answer": {
+                            "def": {
+                              "type": "default",
+                              "innerType": {
+                                "def": {
+                                  "type": "string"
+                                },
+                                "type": "string",
+                                "format": null,
+                                "minLength": null,
+                                "maxLength": null
+                              },
+                              "defaultValue": ""
+                            },
+                            "type": "default"
+                          },
+                          "commonStandardId": {
+                            "def": {
+                              "type": "literal",
+                              "values": [
+                                "title"
+                              ]
+                            },
+                            "type": "literal",
+                            "values": {}
+                          }
+                        }
+                      },
+                      "type": "object"
+                    },
+                    {
+                      "def": {
+                        "type": "object",
+                        "shape": {
+                          "type": {
+                            "def": {
+                              "type": "literal",
+                              "values": [
+                                "textArea"
+                              ]
+                            },
+                            "type": "literal",
+                            "values": {}
+                          },
+                          "meta": {
+                            "def": {
+                              "type": "object",
+                              "shape": {
+                                "schemaVersion": {
+                                  "def": {
+                                    "type": "default",
+                                    "innerType": {
+                                      "def": {
+                                        "type": "string"
+                                      },
+                                      "type": "string",
+                                      "format": null,
+                                      "minLength": null,
+                                      "maxLength": null
+                                    },
+                                    "defaultValue": "1.0"
+                                  },
+                                  "type": "default"
+                                }
+                              }
+                            },
+                            "type": "object"
+                          },
+                          "comment": {
+                            "def": {
+                              "type": "optional",
+                              "innerType": {
+                                "def": {
+                                  "type": "string"
+                                },
+                                "type": "string",
+                                "format": null,
+                                "minLength": null,
+                                "maxLength": null
+                              }
+                            },
+                            "type": "optional"
+                          },
+                          "answer": {
+                            "def": {
+                              "type": "default",
+                              "innerType": {
+                                "def": {
+                                  "type": "string"
+                                },
+                                "type": "string",
+                                "format": null,
+                                "minLength": null,
+                                "maxLength": null
+                              },
+                              "defaultValue": ""
+                            },
+                            "type": "default"
+                          },
+                          "commonStandardId": {
+                            "def": {
+                              "type": "literal",
+                              "values": [
+                                "description"
+                              ]
+                            },
+                            "type": "literal",
+                            "values": {}
+                          }
+                        }
+                      },
+                      "type": "object"
+                    },
+                    {
+                      "def": {
+                        "type": "object",
+                        "shape": {
+                          "type": {
+                            "def": {
+                              "type": "literal",
+                              "values": [
+                                "selectBox"
+                              ]
+                            },
+                            "type": "literal",
+                            "values": {}
+                          },
+                          "meta": {
+                            "def": {
+                              "type": "object",
+                              "shape": {
+                                "schemaVersion": {
+                                  "def": {
+                                    "type": "default",
+                                    "innerType": {
+                                      "def": {
+                                        "type": "string"
+                                      },
+                                      "type": "string",
+                                      "format": null,
+                                      "minLength": null,
+                                      "maxLength": null
+                                    },
+                                    "defaultValue": "1.0"
+                                  },
+                                  "type": "default"
+                                }
+                              }
+                            },
+                            "type": "object"
+                          },
+                          "comment": {
+                            "def": {
+                              "type": "optional",
+                              "innerType": {
+                                "def": {
+                                  "type": "string"
+                                },
+                                "type": "string",
+                                "format": null,
+                                "minLength": null,
+                                "maxLength": null
+                              }
+                            },
+                            "type": "optional"
+                          },
+                          "answer": {
+                            "def": {
+                              "type": "default",
+                              "innerType": {
+                                "def": {
+                                  "type": "string"
+                                },
+                                "type": "string",
+                                "format": null,
+                                "minLength": null,
+                                "maxLength": null
+                              },
+                              "defaultValue": ""
+                            },
+                            "type": "default"
+                          },
+                          "commonStandardId": {
+                            "def": {
+                              "type": "literal",
+                              "values": [
+                                "type"
+                              ]
+                            },
+                            "type": "literal",
+                            "values": {}
+                          }
+                        }
+                      },
+                      "type": "object"
+                    },
                     {
                       "def": {
                         "type": "object",
@@ -8332,6 +8812,58 @@
                           },
                           "commonStandardId": {
                             "def": {
+                              "type": "literal",
+                              "values": [
+                                "data_flags"
+                              ]
+                            },
+                            "type": "literal",
+                            "values": {}
+                          }
+                        }
+                      },
+                      "type": "object"
+                    },
+                    {
+                      "def": {
+                        "type": "object",
+                        "shape": {
+                          "type": {
+                            "def": {
+                              "type": "literal",
+                              "values": [
+                                "radioButtons"
+                              ]
+                            },
+                            "type": "literal",
+                            "values": {}
+                          },
+                          "meta": {
+                            "def": {
+                              "type": "object",
+                              "shape": {
+                                "schemaVersion": {
+                                  "def": {
+                                    "type": "default",
+                                    "innerType": {
+                                      "def": {
+                                        "type": "string"
+                                      },
+                                      "type": "string",
+                                      "format": null,
+                                      "minLength": null,
+                                      "maxLength": null
+                                    },
+                                    "defaultValue": "1.0"
+                                  },
+                                  "type": "default"
+                                }
+                              }
+                            },
+                            "type": "object"
+                          },
+                          "comment": {
+                            "def": {
                               "type": "optional",
                               "innerType": {
                                 "def": {
@@ -8344,6 +8876,32 @@
                               }
                             },
                             "type": "optional"
+                          },
+                          "answer": {
+                            "def": {
+                              "type": "default",
+                              "innerType": {
+                                "def": {
+                                  "type": "string"
+                                },
+                                "type": "string",
+                                "format": null,
+                                "minLength": null,
+                                "maxLength": null
+                              },
+                              "defaultValue": ""
+                            },
+                            "type": "default"
+                          },
+                          "commonStandardId": {
+                            "def": {
+                              "type": "literal",
+                              "values": [
+                                "data_access"
+                              ]
+                            },
+                            "type": "literal",
+                            "values": {}
                           }
                         }
                       },
@@ -8420,348 +8978,13 @@
                           },
                           "commonStandardId": {
                             "def": {
-                              "type": "optional",
-                              "innerType": {
-                                "def": {
-                                  "type": "string"
-                                },
-                                "type": "string",
-                                "format": null,
-                                "minLength": null,
-                                "maxLength": null
-                              }
-                            },
-                            "type": "optional"
-                          }
-                        }
-                      },
-                      "type": "object"
-                    },
-                    {
-                      "def": {
-                        "type": "object",
-                        "shape": {
-                          "type": {
-                            "def": {
                               "type": "literal",
                               "values": [
-                                "licenseSearch"
+                                "issued"
                               ]
                             },
                             "type": "literal",
                             "values": {}
-                          },
-                          "meta": {
-                            "def": {
-                              "type": "object",
-                              "shape": {
-                                "schemaVersion": {
-                                  "def": {
-                                    "type": "default",
-                                    "innerType": {
-                                      "def": {
-                                        "type": "string"
-                                      },
-                                      "type": "string",
-                                      "format": null,
-                                      "minLength": null,
-                                      "maxLength": null
-                                    },
-                                    "defaultValue": "1.0"
-                                  },
-                                  "type": "default"
-                                }
-                              }
-                            },
-                            "type": "object"
-                          },
-                          "comment": {
-                            "def": {
-                              "type": "optional",
-                              "innerType": {
-                                "def": {
-                                  "type": "string"
-                                },
-                                "type": "string",
-                                "format": null,
-                                "minLength": null,
-                                "maxLength": null
-                              }
-                            },
-                            "type": "optional"
-                          },
-                          "answer": {
-                            "def": {
-                              "type": "default",
-                              "innerType": {
-                                "def": {
-                                  "type": "array",
-                                  "element": {
-                                    "def": {
-                                      "type": "object",
-                                      "shape": {
-                                        "licenseId": {
-                                          "def": {
-                                            "type": "default",
-                                            "innerType": {
-                                              "def": {
-                                                "type": "string"
-                                              },
-                                              "type": "string",
-                                              "format": null,
-                                              "minLength": null,
-                                              "maxLength": null
-                                            },
-                                            "defaultValue": ""
-                                          },
-                                          "type": "default"
-                                        },
-                                        "licenseName": {
-                                          "def": {
-                                            "type": "default",
-                                            "innerType": {
-                                              "def": {
-                                                "type": "string"
-                                              },
-                                              "type": "string",
-                                              "format": null,
-                                              "minLength": null,
-                                              "maxLength": null
-                                            },
-                                            "defaultValue": ""
-                                          },
-                                          "type": "default"
-                                        }
-                                      }
-                                    },
-                                    "type": "object"
-                                  }
-                                },
-                                "type": "array",
-                                "element": {
-                                  "def": {
-                                    "type": "object",
-                                    "shape": {
-                                      "licenseId": {
-                                        "def": {
-                                          "type": "default",
-                                          "innerType": {
-                                            "def": {
-                                              "type": "string"
-                                            },
-                                            "type": "string",
-                                            "format": null,
-                                            "minLength": null,
-                                            "maxLength": null
-                                          },
-                                          "defaultValue": ""
-                                        },
-                                        "type": "default"
-                                      },
-                                      "licenseName": {
-                                        "def": {
-                                          "type": "default",
-                                          "innerType": {
-                                            "def": {
-                                              "type": "string"
-                                            },
-                                            "type": "string",
-                                            "format": null,
-                                            "minLength": null,
-                                            "maxLength": null
-                                          },
-                                          "defaultValue": ""
-                                        },
-                                        "type": "default"
-                                      }
-                                    }
-                                  },
-                                  "type": "object"
-                                }
-                              },
-                              "defaultValue": []
-                            },
-                            "type": "default"
-                          },
-                          "commonStandardId": {
-                            "def": {
-                              "type": "optional",
-                              "innerType": {
-                                "def": {
-                                  "type": "string"
-                                },
-                                "type": "string",
-                                "format": null,
-                                "minLength": null,
-                                "maxLength": null
-                              }
-                            },
-                            "type": "optional"
-                          }
-                        }
-                      },
-                      "type": "object"
-                    },
-                    {
-                      "def": {
-                        "type": "object",
-                        "shape": {
-                          "type": {
-                            "def": {
-                              "type": "literal",
-                              "values": [
-                                "metadataStandardSearch"
-                              ]
-                            },
-                            "type": "literal",
-                            "values": {}
-                          },
-                          "meta": {
-                            "def": {
-                              "type": "object",
-                              "shape": {
-                                "schemaVersion": {
-                                  "def": {
-                                    "type": "default",
-                                    "innerType": {
-                                      "def": {
-                                        "type": "string"
-                                      },
-                                      "type": "string",
-                                      "format": null,
-                                      "minLength": null,
-                                      "maxLength": null
-                                    },
-                                    "defaultValue": "1.0"
-                                  },
-                                  "type": "default"
-                                }
-                              }
-                            },
-                            "type": "object"
-                          },
-                          "comment": {
-                            "def": {
-                              "type": "optional",
-                              "innerType": {
-                                "def": {
-                                  "type": "string"
-                                },
-                                "type": "string",
-                                "format": null,
-                                "minLength": null,
-                                "maxLength": null
-                              }
-                            },
-                            "type": "optional"
-                          },
-                          "answer": {
-                            "def": {
-                              "type": "default",
-                              "innerType": {
-                                "def": {
-                                  "type": "array",
-                                  "element": {
-                                    "def": {
-                                      "type": "object",
-                                      "shape": {
-                                        "metadataStandardId": {
-                                          "def": {
-                                            "type": "default",
-                                            "innerType": {
-                                              "def": {
-                                                "type": "string"
-                                              },
-                                              "type": "string",
-                                              "format": null,
-                                              "minLength": null,
-                                              "maxLength": null
-                                            },
-                                            "defaultValue": ""
-                                          },
-                                          "type": "default"
-                                        },
-                                        "metadataStandardName": {
-                                          "def": {
-                                            "type": "default",
-                                            "innerType": {
-                                              "def": {
-                                                "type": "string"
-                                              },
-                                              "type": "string",
-                                              "format": null,
-                                              "minLength": null,
-                                              "maxLength": null
-                                            },
-                                            "defaultValue": ""
-                                          },
-                                          "type": "default"
-                                        }
-                                      }
-                                    },
-                                    "type": "object"
-                                  }
-                                },
-                                "type": "array",
-                                "element": {
-                                  "def": {
-                                    "type": "object",
-                                    "shape": {
-                                      "metadataStandardId": {
-                                        "def": {
-                                          "type": "default",
-                                          "innerType": {
-                                            "def": {
-                                              "type": "string"
-                                            },
-                                            "type": "string",
-                                            "format": null,
-                                            "minLength": null,
-                                            "maxLength": null
-                                          },
-                                          "defaultValue": ""
-                                        },
-                                        "type": "default"
-                                      },
-                                      "metadataStandardName": {
-                                        "def": {
-                                          "type": "default",
-                                          "innerType": {
-                                            "def": {
-                                              "type": "string"
-                                            },
-                                            "type": "string",
-                                            "format": null,
-                                            "minLength": null,
-                                            "maxLength": null
-                                          },
-                                          "defaultValue": ""
-                                        },
-                                        "type": "default"
-                                      }
-                                    }
-                                  },
-                                  "type": "object"
-                                }
-                              },
-                              "defaultValue": []
-                            },
-                            "type": "default"
-                          },
-                          "commonStandardId": {
-                            "def": {
-                              "type": "optional",
-                              "innerType": {
-                                "def": {
-                                  "type": "string"
-                                },
-                                "type": "string",
-                                "format": null,
-                                "minLength": null,
-                                "maxLength": null
-                              }
-                            },
-                            "type": "optional"
                           }
                         }
                       },
@@ -8865,106 +9088,13 @@
                           },
                           "commonStandardId": {
                             "def": {
-                              "type": "optional",
-                              "innerType": {
-                                "def": {
-                                  "type": "string"
-                                },
-                                "type": "string",
-                                "format": null,
-                                "minLength": null,
-                                "maxLength": null
-                              }
-                            },
-                            "type": "optional"
-                          }
-                        }
-                      },
-                      "type": "object"
-                    },
-                    {
-                      "def": {
-                        "type": "object",
-                        "shape": {
-                          "type": {
-                            "def": {
                               "type": "literal",
                               "values": [
-                                "radioButtons"
+                                "byte_size"
                               ]
                             },
                             "type": "literal",
                             "values": {}
-                          },
-                          "meta": {
-                            "def": {
-                              "type": "object",
-                              "shape": {
-                                "schemaVersion": {
-                                  "def": {
-                                    "type": "default",
-                                    "innerType": {
-                                      "def": {
-                                        "type": "string"
-                                      },
-                                      "type": "string",
-                                      "format": null,
-                                      "minLength": null,
-                                      "maxLength": null
-                                    },
-                                    "defaultValue": "1.0"
-                                  },
-                                  "type": "default"
-                                }
-                              }
-                            },
-                            "type": "object"
-                          },
-                          "comment": {
-                            "def": {
-                              "type": "optional",
-                              "innerType": {
-                                "def": {
-                                  "type": "string"
-                                },
-                                "type": "string",
-                                "format": null,
-                                "minLength": null,
-                                "maxLength": null
-                              }
-                            },
-                            "type": "optional"
-                          },
-                          "answer": {
-                            "def": {
-                              "type": "default",
-                              "innerType": {
-                                "def": {
-                                  "type": "string"
-                                },
-                                "type": "string",
-                                "format": null,
-                                "minLength": null,
-                                "maxLength": null
-                              },
-                              "defaultValue": ""
-                            },
-                            "type": "default"
-                          },
-                          "commonStandardId": {
-                            "def": {
-                              "type": "optional",
-                              "innerType": {
-                                "def": {
-                                  "type": "string"
-                                },
-                                "type": "string",
-                                "format": null,
-                                "minLength": null,
-                                "maxLength": null
-                              }
-                            },
-                            "type": "optional"
                           }
                         }
                       },
@@ -9118,18 +9248,13 @@
                           },
                           "commonStandardId": {
                             "def": {
-                              "type": "optional",
-                              "innerType": {
-                                "def": {
-                                  "type": "string"
-                                },
-                                "type": "string",
-                                "format": null,
-                                "minLength": null,
-                                "maxLength": null
-                              }
+                              "type": "literal",
+                              "values": [
+                                "host"
+                              ]
                             },
-                            "type": "optional"
+                            "type": "literal",
+                            "values": {}
                           }
                         }
                       },
@@ -9143,7 +9268,7 @@
                             "def": {
                               "type": "literal",
                               "values": [
-                                "selectBox"
+                                "metadataStandardSearch"
                               ]
                             },
                             "type": "literal",
@@ -9193,18 +9318,147 @@
                               "type": "default",
                               "innerType": {
                                 "def": {
-                                  "type": "string"
+                                  "type": "array",
+                                  "element": {
+                                    "def": {
+                                      "type": "object",
+                                      "shape": {
+                                        "metadataStandardId": {
+                                          "def": {
+                                            "type": "default",
+                                            "innerType": {
+                                              "def": {
+                                                "type": "string"
+                                              },
+                                              "type": "string",
+                                              "format": null,
+                                              "minLength": null,
+                                              "maxLength": null
+                                            },
+                                            "defaultValue": ""
+                                          },
+                                          "type": "default"
+                                        },
+                                        "metadataStandardName": {
+                                          "def": {
+                                            "type": "default",
+                                            "innerType": {
+                                              "def": {
+                                                "type": "string"
+                                              },
+                                              "type": "string",
+                                              "format": null,
+                                              "minLength": null,
+                                              "maxLength": null
+                                            },
+                                            "defaultValue": ""
+                                          },
+                                          "type": "default"
+                                        }
+                                      }
+                                    },
+                                    "type": "object"
+                                  }
                                 },
-                                "type": "string",
-                                "format": null,
-                                "minLength": null,
-                                "maxLength": null
+                                "type": "array",
+                                "element": {
+                                  "def": {
+                                    "type": "object",
+                                    "shape": {
+                                      "metadataStandardId": {
+                                        "def": {
+                                          "type": "default",
+                                          "innerType": {
+                                            "def": {
+                                              "type": "string"
+                                            },
+                                            "type": "string",
+                                            "format": null,
+                                            "minLength": null,
+                                            "maxLength": null
+                                          },
+                                          "defaultValue": ""
+                                        },
+                                        "type": "default"
+                                      },
+                                      "metadataStandardName": {
+                                        "def": {
+                                          "type": "default",
+                                          "innerType": {
+                                            "def": {
+                                              "type": "string"
+                                            },
+                                            "type": "string",
+                                            "format": null,
+                                            "minLength": null,
+                                            "maxLength": null
+                                          },
+                                          "defaultValue": ""
+                                        },
+                                        "type": "default"
+                                      }
+                                    }
+                                  },
+                                  "type": "object"
+                                }
                               },
-                              "defaultValue": ""
+                              "defaultValue": []
                             },
                             "type": "default"
                           },
                           "commonStandardId": {
+                            "def": {
+                              "type": "literal",
+                              "values": [
+                                "metadata"
+                              ]
+                            },
+                            "type": "literal",
+                            "values": {}
+                          }
+                        }
+                      },
+                      "type": "object"
+                    },
+                    {
+                      "def": {
+                        "type": "object",
+                        "shape": {
+                          "type": {
+                            "def": {
+                              "type": "literal",
+                              "values": [
+                                "licenseSearch"
+                              ]
+                            },
+                            "type": "literal",
+                            "values": {}
+                          },
+                          "meta": {
+                            "def": {
+                              "type": "object",
+                              "shape": {
+                                "schemaVersion": {
+                                  "def": {
+                                    "type": "default",
+                                    "innerType": {
+                                      "def": {
+                                        "type": "string"
+                                      },
+                                      "type": "string",
+                                      "format": null,
+                                      "minLength": null,
+                                      "maxLength": null
+                                    },
+                                    "defaultValue": "1.0"
+                                  },
+                                  "type": "default"
+                                }
+                              }
+                            },
+                            "type": "object"
+                          },
+                          "comment": {
                             "def": {
                               "type": "optional",
                               "innerType": {
@@ -9218,6 +9472,109 @@
                               }
                             },
                             "type": "optional"
+                          },
+                          "answer": {
+                            "def": {
+                              "type": "default",
+                              "innerType": {
+                                "def": {
+                                  "type": "array",
+                                  "element": {
+                                    "def": {
+                                      "type": "object",
+                                      "shape": {
+                                        "licenseId": {
+                                          "def": {
+                                            "type": "default",
+                                            "innerType": {
+                                              "def": {
+                                                "type": "string"
+                                              },
+                                              "type": "string",
+                                              "format": null,
+                                              "minLength": null,
+                                              "maxLength": null
+                                            },
+                                            "defaultValue": ""
+                                          },
+                                          "type": "default"
+                                        },
+                                        "licenseName": {
+                                          "def": {
+                                            "type": "default",
+                                            "innerType": {
+                                              "def": {
+                                                "type": "string"
+                                              },
+                                              "type": "string",
+                                              "format": null,
+                                              "minLength": null,
+                                              "maxLength": null
+                                            },
+                                            "defaultValue": ""
+                                          },
+                                          "type": "default"
+                                        }
+                                      }
+                                    },
+                                    "type": "object"
+                                  }
+                                },
+                                "type": "array",
+                                "element": {
+                                  "def": {
+                                    "type": "object",
+                                    "shape": {
+                                      "licenseId": {
+                                        "def": {
+                                          "type": "default",
+                                          "innerType": {
+                                            "def": {
+                                              "type": "string"
+                                            },
+                                            "type": "string",
+                                            "format": null,
+                                            "minLength": null,
+                                            "maxLength": null
+                                          },
+                                          "defaultValue": ""
+                                        },
+                                        "type": "default"
+                                      },
+                                      "licenseName": {
+                                        "def": {
+                                          "type": "default",
+                                          "innerType": {
+                                            "def": {
+                                              "type": "string"
+                                            },
+                                            "type": "string",
+                                            "format": null,
+                                            "minLength": null,
+                                            "maxLength": null
+                                          },
+                                          "defaultValue": ""
+                                        },
+                                        "type": "default"
+                                      }
+                                    }
+                                  },
+                                  "type": "object"
+                                }
+                              },
+                              "defaultValue": []
+                            },
+                            "type": "default"
+                          },
+                          "commonStandardId": {
+                            "def": {
+                              "type": "literal",
+                              "values": [
+                                "license_ref"
+                              ]
+                            },
+                            "type": "literal",
+                            "values": {}
                           }
                         }
                       },
@@ -9294,106 +9651,13 @@
                           },
                           "commonStandardId": {
                             "def": {
-                              "type": "optional",
-                              "innerType": {
-                                "def": {
-                                  "type": "string"
-                                },
-                                "type": "string",
-                                "format": null,
-                                "minLength": null,
-                                "maxLength": null
-                              }
-                            },
-                            "type": "optional"
-                          }
-                        }
-                      },
-                      "type": "object"
-                    },
-                    {
-                      "def": {
-                        "type": "object",
-                        "shape": {
-                          "type": {
-                            "def": {
                               "type": "literal",
                               "values": [
-                                "textArea"
+                                "custom"
                               ]
                             },
                             "type": "literal",
                             "values": {}
-                          },
-                          "meta": {
-                            "def": {
-                              "type": "object",
-                              "shape": {
-                                "schemaVersion": {
-                                  "def": {
-                                    "type": "default",
-                                    "innerType": {
-                                      "def": {
-                                        "type": "string"
-                                      },
-                                      "type": "string",
-                                      "format": null,
-                                      "minLength": null,
-                                      "maxLength": null
-                                    },
-                                    "defaultValue": "1.0"
-                                  },
-                                  "type": "default"
-                                }
-                              }
-                            },
-                            "type": "object"
-                          },
-                          "comment": {
-                            "def": {
-                              "type": "optional",
-                              "innerType": {
-                                "def": {
-                                  "type": "string"
-                                },
-                                "type": "string",
-                                "format": null,
-                                "minLength": null,
-                                "maxLength": null
-                              }
-                            },
-                            "type": "optional"
-                          },
-                          "answer": {
-                            "def": {
-                              "type": "default",
-                              "innerType": {
-                                "def": {
-                                  "type": "string"
-                                },
-                                "type": "string",
-                                "format": null,
-                                "minLength": null,
-                                "maxLength": null
-                              },
-                              "defaultValue": ""
-                            },
-                            "type": "default"
-                          },
-                          "commonStandardId": {
-                            "def": {
-                              "type": "optional",
-                              "innerType": {
-                                "def": {
-                                  "type": "string"
-                                },
-                                "type": "string",
-                                "format": null,
-                                "minLength": null,
-                                "maxLength": null
-                              }
-                            },
-                            "type": "optional"
                           }
                         }
                       },

--- a/schemas/researchOutputTableQuestion.schema.json
+++ b/schemas/researchOutputTableQuestion.schema.json
@@ -152,7 +152,8 @@
                 "additionalProperties": false
               },
               "commonStandardId": {
-                "type": "string"
+                "type": "string",
+                "const": "title"
               }
             },
             "required": [
@@ -160,7 +161,8 @@
               "help",
               "required",
               "enabled",
-              "content"
+              "content",
+              "commonStandardId"
             ],
             "additionalProperties": false
           },
@@ -264,7 +266,8 @@
                 "additionalProperties": false
               },
               "commonStandardId": {
-                "type": "string"
+                "type": "string",
+                "const": "description"
               }
             },
             "required": [
@@ -272,7 +275,8 @@
               "help",
               "required",
               "enabled",
-              "content"
+              "content",
+              "commonStandardId"
             ],
             "additionalProperties": false
           },
@@ -384,7 +388,8 @@
                 "additionalProperties": false
               },
               "commonStandardId": {
-                "type": "string"
+                "type": "string",
+                "const": "type"
               }
             },
             "required": [
@@ -392,7 +397,8 @@
               "help",
               "required",
               "enabled",
-              "content"
+              "content",
+              "commonStandardId"
             ],
             "additionalProperties": false
           },
@@ -497,7 +503,8 @@
                 "additionalProperties": false
               },
               "commonStandardId": {
-                "type": "string"
+                "type": "string",
+                "const": "data_flags"
               }
             },
             "required": [
@@ -505,7 +512,8 @@
               "help",
               "required",
               "enabled",
-              "content"
+              "content",
+              "commonStandardId"
             ],
             "additionalProperties": false
           },
@@ -610,7 +618,8 @@
                 "additionalProperties": false
               },
               "commonStandardId": {
-                "type": "string"
+                "type": "string",
+                "const": "data_access"
               }
             },
             "required": [
@@ -618,7 +627,8 @@
               "help",
               "required",
               "enabled",
-              "content"
+              "content",
+              "commonStandardId"
             ],
             "additionalProperties": false
           },
@@ -707,7 +717,8 @@
                 "additionalProperties": false
               },
               "commonStandardId": {
-                "type": "string"
+                "type": "string",
+                "const": "issued"
               }
             },
             "required": [
@@ -715,7 +726,8 @@
               "help",
               "required",
               "enabled",
-              "content"
+              "content",
+              "commonStandardId"
             ],
             "additionalProperties": false
           },
@@ -836,7 +848,8 @@
                 "additionalProperties": false
               },
               "commonStandardId": {
-                "type": "string"
+                "type": "string",
+                "const": "byte_size"
               }
             },
             "required": [
@@ -844,7 +857,8 @@
               "help",
               "required",
               "enabled",
-              "content"
+              "content",
+              "commonStandardId"
             ],
             "additionalProperties": false
           },
@@ -1007,7 +1021,8 @@
                 "additionalProperties": false
               },
               "commonStandardId": {
-                "type": "string"
+                "type": "string",
+                "const": "host"
               },
               "preferences": {
                 "default": [],
@@ -1038,6 +1053,7 @@
               "required",
               "enabled",
               "content",
+              "commonStandardId",
               "preferences"
             ],
             "additionalProperties": false
@@ -1202,7 +1218,8 @@
                 "additionalProperties": false
               },
               "commonStandardId": {
-                "type": "string"
+                "type": "string",
+                "const": "metadata"
               },
               "preferences": {
                 "default": [],
@@ -1233,6 +1250,7 @@
               "required",
               "enabled",
               "content",
+              "commonStandardId",
               "preferences"
             ],
             "additionalProperties": false
@@ -1396,7 +1414,8 @@
                 "additionalProperties": false
               },
               "commonStandardId": {
-                "type": "string"
+                "type": "string",
+                "const": "license_ref"
               },
               "preferences": {
                 "default": [],
@@ -1427,6 +1446,7 @@
               "required",
               "enabled",
               "content",
+              "commonStandardId",
               "preferences"
             ],
             "additionalProperties": false
@@ -1510,6 +1530,10 @@
                   "meta"
                 ],
                 "additionalProperties": false
+              },
+              "commonStandardId": {
+                "type": "string",
+                "const": "custom"
               }
             },
             "required": [
@@ -1517,7 +1541,8 @@
               "help",
               "required",
               "enabled",
-              "content"
+              "content",
+              "commonStandardId"
             ],
             "additionalProperties": false
           }

--- a/src/answers/__tests__/answers.spec.ts
+++ b/src/answers/__tests__/answers.spec.ts
@@ -210,7 +210,7 @@ describe('Answer Type Validations', () => {
             meta: { schemaVersion: CURRENT_SCHEMA_VERSION }
           },
           {
-            type: 'selectBox',
+            type: 'radioButtons',
             commonStandardId: 'data_access',
             answer: 'open',
             meta: { schemaVersion: CURRENT_SCHEMA_VERSION }

--- a/src/answers/__tests__/defaults.spec.ts
+++ b/src/answers/__tests__/defaults.spec.ts
@@ -256,7 +256,7 @@ describe('Get question answer defaultJSON', () => {
           {
             type: "selectBox",
             commonStandardId: 'type',
-            answer: "",
+            answer: "dataset",
             meta: { schemaVersion: CURRENT_SCHEMA_VERSION },
           }
         ]

--- a/src/answers/index.ts
+++ b/src/answers/index.ts
@@ -1,4 +1,4 @@
-import { z } from 'zod';
+import {z, ZodObject} from 'zod';
 import {
   DateAnswerSchema,
   DateAnswerType,
@@ -53,10 +53,43 @@ import {
   NumberWithContextAnswerType
 } from './numberAnswers';
 import {
+  DefaultResearchOutputAccessLevelAnswer,
+  DefaultResearchOutputByteSizeAnswer,
+  DefaultResearchOutputCustomTableAnswer,
+  DefaultResearchOutputDataFlagsAnswer,
+  DefaultResearchOutputDescriptionAnswer,
+  DefaultResearchOutputLicenseAnswer,
+  DefaultResearchOutputMetadataStandardAnswer,
+  DefaultResearchOutputReleaseDateAnswer,
+  DefaultResearchOutputRepositoryAnswer,
   DefaultResearchOutputTableAnswer,
+  DefaultResearchOutputTitleAnswer,
+  DefaultResearchOutputTypeAnswer,
   DefaultTableAnswer,
+  ResearchOutputAccessLevelAnswerSchema,
+  ResearchOutputAccessLevelColumnAnswerType,
+  ResearchOutputByteSizeAnswerSchema,
+  ResearchOutputByteSizeColumnAnswerType,
+  ResearchOutputCustomTableAnswerSchema,
+  ResearchOutputCustomTableColumnAnswerType,
+  ResearchOutputDataFlagsAnswerSchema,
+  ResearchOutputDataFlagsColumnAnswerType,
+  ResearchOutputDescriptionAnswerSchema,
+  ResearchOutputDescriptionColumnAnswerType,
+  ResearchOutputLicenseAnswerSchema,
+  ResearchOutputLicenseColumnAnswerType,
+  ResearchOutputMetadataStandardAnswerSchema,
+  ResearchOutputMetadataStandardColumnAnswerType,
+  ResearchOutputReleaseDateAnswerSchema,
+  ResearchOutputReleaseDateColumnAnswerType,
+  ResearchOutputRepositoryAnswerSchema,
+  ResearchOutputRepositoryColumnAnswerType,
   ResearchOutputTableAnswerSchema,
   ResearchOutputTableAnswerType,
+  ResearchOutputTitleAnswerSchema,
+  ResearchOutputTitleColumnAnswerType,
+  ResearchOutputTypeAnswerSchema,
+  ResearchOutputTypeColumnAnswerType,
   TableAnswerSchema,
   TableAnswerType
 } from './tableAnswers';
@@ -74,7 +107,7 @@ import {
   URLAnswerSchema,
   URLAnswerType
 } from './textAnswers';
-import { QuestionFormatsEnum } from "../questions";
+import { QuestionFormatsEnum, ResearchOutputTableColumnsEnum } from "../questions";
 
 // reexport everything
 export * from './answer';
@@ -210,3 +243,58 @@ export const AnswerDefaultMap: Record<z.infer<typeof QuestionFormatsEnum>, AllDe
   textArea: DefaultTextAreaAnswer,
   url: DefaultURLAnswer,
 };
+
+export type AllDefaultResearchOutputTableColumnAnswerTypes =
+  | typeof DefaultResearchOutputTitleAnswer
+  | typeof DefaultResearchOutputDescriptionAnswer
+  | typeof DefaultResearchOutputTypeAnswer
+  | typeof DefaultResearchOutputDataFlagsAnswer
+  | typeof DefaultResearchOutputAccessLevelAnswer
+  | typeof DefaultResearchOutputReleaseDateAnswer
+  | typeof DefaultResearchOutputByteSizeAnswer
+  | typeof DefaultResearchOutputRepositoryAnswer
+  | typeof DefaultResearchOutputMetadataStandardAnswer
+  | typeof DefaultResearchOutputLicenseAnswer
+  | typeof DefaultResearchOutputCustomTableAnswer;
+
+export interface ResearchOutputTableColumnAnswerTypeMap {
+  title: ResearchOutputTitleColumnAnswerType;
+  description: ResearchOutputDescriptionColumnAnswerType;
+  type: ResearchOutputTypeColumnAnswerType;
+  data_flags: ResearchOutputDataFlagsColumnAnswerType;
+  data_access: ResearchOutputAccessLevelColumnAnswerType;
+  issued: ResearchOutputReleaseDateColumnAnswerType;
+  byte_size: ResearchOutputByteSizeColumnAnswerType;
+  host: ResearchOutputRepositoryColumnAnswerType;
+  metadata: ResearchOutputMetadataStandardColumnAnswerType;
+  license_ref: ResearchOutputLicenseColumnAnswerType;
+  custom: ResearchOutputCustomTableColumnAnswerType;
+}
+
+export const ResearchOutputTableColumnAnswerMap: Record<string, ZodObject> = {
+  title: ResearchOutputTitleAnswerSchema,
+  description: ResearchOutputDescriptionAnswerSchema,
+  type: ResearchOutputTypeAnswerSchema,
+  data_flags: ResearchOutputDataFlagsAnswerSchema,
+  data_access: ResearchOutputAccessLevelAnswerSchema,
+  issued: ResearchOutputReleaseDateAnswerSchema,
+  byte_size: ResearchOutputByteSizeAnswerSchema,
+  host: ResearchOutputRepositoryAnswerSchema,
+  metadata: ResearchOutputMetadataStandardAnswerSchema,
+  license_ref: ResearchOutputLicenseAnswerSchema,
+  custom: ResearchOutputCustomTableAnswerSchema,
+}
+
+export const DefaultResearchOutputTableColumnAnswerMap: Record<z.infer<typeof ResearchOutputTableColumnsEnum>, AllDefaultResearchOutputTableColumnAnswerTypes> = {
+  title: DefaultResearchOutputTitleAnswer,
+  description: DefaultResearchOutputDescriptionAnswer,
+  type: DefaultResearchOutputTypeAnswer,
+  data_flags: DefaultResearchOutputDataFlagsAnswer,
+  data_access: DefaultResearchOutputAccessLevelAnswer,
+  issued: DefaultResearchOutputReleaseDateAnswer,
+  byte_size: DefaultResearchOutputByteSizeAnswer,
+  host: DefaultResearchOutputRepositoryAnswer,
+  metadata: DefaultResearchOutputMetadataStandardAnswer,
+  license_ref: DefaultResearchOutputLicenseAnswer,
+  custom: DefaultResearchOutputCustomTableAnswer
+}

--- a/src/answers/tableAnswers.ts
+++ b/src/answers/tableAnswers.ts
@@ -2,7 +2,7 @@ import { z } from 'zod';
 import { AnswerSchema } from './answer';
 import {
   BooleanAnswerSchema,
-  CheckboxesAnswerSchema,
+  CheckboxesAnswerSchema, DefaultCheckboxesAnswer, DefaultRadioButtonsAnswer,
   DefaultSelectBoxAnswer,
   MultiselectBoxAnswerSchema,
   RadioButtonsAnswerSchema,
@@ -10,16 +10,17 @@ import {
 } from './optionBasedAnswers';
 import {
   DateAnswerSchema,
-  DateRangeAnswerSchema
+  DateRangeAnswerSchema, DefaultDateAnswer
 } from './dateAnswers';
 import {
-  AffiliationSearchAnswerSchema,
+  AffiliationSearchAnswerSchema, DefaultLicenseSearchAnswer,
+  DefaultMetadataStandardSearchAnswer, DefaultRepositorySearchAnswer,
   LicenseSearchAnswerSchema,
   MetadataStandardSearchAnswerSchema,
   RepositorySearchAnswerSchema
 } from './graphQLAnswers';
 import {
-  CurrencyAnswerSchema,
+  CurrencyAnswerSchema, DefaultNumberWithContextAnswer,
   NumberAnswerSchema,
   NumberWithContextAnswerSchema
 } from './numberAnswers';
@@ -31,9 +32,7 @@ import {
   TextAreaAnswerSchema,
   URLAnswerSchema
 } from './textAnswers';
-import {
-  DefaultMeta,
-} from "../questions";
+import { DefaultMeta } from "../questions";
 
 // Answers to Table Column Question Types (note that TableAnswer is not included here because we don't allow nested tables)
 export const AnyTableColumnAnswerSchema = z.discriminatedUnion('type', [
@@ -60,57 +59,118 @@ export const AnyTableColumnAnswerSchema = z.discriminatedUnion('type', [
 // A subset of AnyTableColumnAnswerSchema that includes the commonStandardId field.
 // This is used to map answers in the Research Output table to elements of the
 // RDA Common Standard.
-const roCheckBoxesAnswerSchema = z.object({
-  ...CheckboxesAnswerSchema.shape,
-  commonStandardId: z.string().optional()
-});
-const roDateAnswerSchema = z.object({
-  ...DateAnswerSchema.shape,
-  commonStandardId: z.string().optional()
-});
-const roLicenseSearchAnswerSchema = z.object({
-  ...LicenseSearchAnswerSchema.shape,
-  commonStandardId: z.string().optional()
-});
-const roMetadataStandardSearchAnswerSchema = z.object({
-  ...MetadataStandardSearchAnswerSchema.shape,
-  commonStandardId: z.string().optional()
-});
-const roNumberWithContextAnswerSchema = z.object({
-  ...NumberWithContextAnswerSchema.shape,
-  commonStandardId: z.string().optional()
-});
-const roRadioButtonsAnswerSchema = z.object({
-  ...RadioButtonsAnswerSchema.shape,
-  commonStandardId: z.string().optional()
-});
-const roRepositorySearchAnswerSchema = z.object({
-  ...RepositorySearchAnswerSchema.shape,
-  commonStandardId: z.string().optional()
-});
-const roSelectBoxAnswerSchema = z.object({
-  ...SelectBoxAnswerSchema.shape,
-  commonStandardId: z.string().optional()
-});
-const roTextAnswerSchema = z.object({
+export const ResearchOutputTitleAnswerSchema = z.object({
   ...TextAnswerSchema.shape,
-  commonStandardId: z.string().optional()
+  commonStandardId: z.literal('title')
 });
-const roTextAreaAnswerSchema = z.object({
+export const DefaultResearchOutputTitleAnswer = ResearchOutputTitleAnswerSchema.parse({
+  ...DefaultTextAnswer,
+  commonStandardId: 'title'
+});
+
+export const ResearchOutputDescriptionAnswerSchema = z.object({
   ...TextAreaAnswerSchema.shape,
-  commonStandardId: z.string().optional()
+  commonStandardId: z.literal('description')
 });
-export const AnyResearchOutputTableColumnAnswerSchema = z.discriminatedUnion('type', [
-  roCheckBoxesAnswerSchema,
-  roDateAnswerSchema,
-  roLicenseSearchAnswerSchema,
-  roMetadataStandardSearchAnswerSchema,
-  roNumberWithContextAnswerSchema,
-  roRadioButtonsAnswerSchema,
-  roRepositorySearchAnswerSchema,
-  roSelectBoxAnswerSchema,
-  roTextAnswerSchema,
-  roTextAreaAnswerSchema
+export const DefaultResearchOutputDescriptionAnswer = ResearchOutputDescriptionAnswerSchema.parse({
+  ...DefaultTextAreaAnswer,
+  commonStandardId: 'description'
+});
+
+export const ResearchOutputTypeAnswerSchema = z.object({
+  ...SelectBoxAnswerSchema.shape,
+  commonStandardId: z.literal('type')
+});
+export const DefaultResearchOutputTypeAnswer = ResearchOutputTypeAnswerSchema.parse({
+  ...DefaultSelectBoxAnswer,
+  answer: 'dataset',
+  commonStandardId: 'type'
+});
+
+export const ResearchOutputDataFlagsAnswerSchema = z.object({
+  ...CheckboxesAnswerSchema.shape,
+  commonStandardId: z.literal('data_flags')
+});
+export const DefaultResearchOutputDataFlagsAnswer = ResearchOutputDataFlagsAnswerSchema.parse({
+  ...DefaultCheckboxesAnswer,
+  commonStandardId: 'data_flags'
+});
+
+export const ResearchOutputAccessLevelAnswerSchema = z.object({
+  ...RadioButtonsAnswerSchema.shape,
+  commonStandardId: z.literal('data_access')
+});
+export const DefaultResearchOutputAccessLevelAnswer = ResearchOutputAccessLevelAnswerSchema.parse({
+  ...DefaultRadioButtonsAnswer,
+  commonStandardId: 'data_access'
+});
+
+export const ResearchOutputReleaseDateAnswerSchema = z.object({
+  ...DateAnswerSchema.shape,
+  commonStandardId: z.literal('issued')
+});
+export const DefaultResearchOutputReleaseDateAnswer = ResearchOutputReleaseDateAnswerSchema.parse({
+  ...DefaultDateAnswer,
+  commonStandardId: 'issued'
+});
+
+export const ResearchOutputByteSizeAnswerSchema = z.object({
+  ...NumberWithContextAnswerSchema.shape,
+  commonStandardId: z.literal('byte_size')
+});
+export const DefaultResearchOutputByteSizeAnswer = ResearchOutputByteSizeAnswerSchema.parse({
+  ...DefaultNumberWithContextAnswer,
+  commonStandardId: 'byte_size'
+});
+
+export const ResearchOutputRepositoryAnswerSchema = z.object({
+  ...RepositorySearchAnswerSchema.shape,
+  commonStandardId: z.literal('host')
+});
+export const DefaultResearchOutputRepositoryAnswer = ResearchOutputRepositoryAnswerSchema.parse({
+  ...DefaultRepositorySearchAnswer,
+  commonStandardId: 'host'
+});
+
+export const ResearchOutputMetadataStandardAnswerSchema = z.object({
+  ...MetadataStandardSearchAnswerSchema.shape,
+  commonStandardId: z.literal('metadata')
+});
+export const DefaultResearchOutputMetadataStandardAnswer = ResearchOutputMetadataStandardAnswerSchema.parse({
+  ...DefaultMetadataStandardSearchAnswer,
+  commonStandardId: 'metadata'
+});
+
+export const ResearchOutputLicenseAnswerSchema = z.object({
+  ...LicenseSearchAnswerSchema.shape,
+  commonStandardId: z.literal('license_ref')
+});
+export const DefaultResearchOutputLicenseAnswer = ResearchOutputLicenseAnswerSchema.parse({
+  ...DefaultLicenseSearchAnswer,
+  commonStandardId: 'license_ref'
+});
+
+export const ResearchOutputCustomTableAnswerSchema = z.object({
+  ...TextAnswerSchema.shape,
+  commonStandardId: z.literal('custom')
+});
+export const DefaultResearchOutputCustomTableAnswer = ResearchOutputCustomTableAnswerSchema.parse({
+  ...DefaultTextAnswer,
+  commonStandardId: 'custom'
+})
+
+export const AnyResearchOutputTableColumnAnswerSchema = z.discriminatedUnion('commonStandardId', [
+  ResearchOutputTitleAnswerSchema,
+  ResearchOutputDescriptionAnswerSchema,
+  ResearchOutputTypeAnswerSchema,
+  ResearchOutputDataFlagsAnswerSchema,
+  ResearchOutputAccessLevelAnswerSchema,
+  ResearchOutputReleaseDateAnswerSchema,
+  ResearchOutputByteSizeAnswerSchema,
+  ResearchOutputRepositoryAnswerSchema,
+  ResearchOutputMetadataStandardAnswerSchema,
+  ResearchOutputLicenseAnswerSchema,
+  ResearchOutputCustomTableAnswerSchema
 ]);
 
 export const TableRowAnswerSchema = z.object({
@@ -125,14 +185,8 @@ export const ResearchOutputTableRowAnswerSchema = z.object({
 })
 export const DefaultResearchOutputTableRowAnswer = ResearchOutputTableRowAnswerSchema.parse({
   columns: [
-    {
-      ...DefaultTextAnswer,
-      commonStandardId: 'title',
-    },
-    {
-      ...DefaultSelectBoxAnswer,
-      commonStandardId: 'type',
-    },
+    DefaultResearchOutputTitleAnswer,
+    DefaultResearchOutputTypeAnswer,
   ]
 });
 
@@ -168,6 +222,17 @@ export type TableAnswerType = z.infer<typeof TableAnswerSchema>;
 export type ResearchOutputTableAnswerType = z.infer<typeof ResearchOutputTableAnswerSchema>;
 export type TableRowAnswerType = z.infer<typeof TableRowAnswerSchema>;
 export type ResearchOutputTableRowAnswerType = z.infer<typeof ResearchOutputTableRowAnswerSchema>;
+export type ResearchOutputTitleColumnAnswerType = z.infer<typeof ResearchOutputTitleAnswerSchema>;
+export type ResearchOutputDescriptionColumnAnswerType = z.infer<typeof ResearchOutputDescriptionAnswerSchema>;
+export type ResearchOutputTypeColumnAnswerType = z.infer<typeof ResearchOutputTypeAnswerSchema>;
+export type ResearchOutputDataFlagsColumnAnswerType = z.infer<typeof ResearchOutputDataFlagsAnswerSchema>;
+export type ResearchOutputAccessLevelColumnAnswerType = z.infer<typeof ResearchOutputAccessLevelAnswerSchema>;
+export type ResearchOutputReleaseDateColumnAnswerType = z.infer<typeof ResearchOutputReleaseDateAnswerSchema>;
+export type ResearchOutputByteSizeColumnAnswerType = z.infer<typeof ResearchOutputByteSizeAnswerSchema>;
+export type ResearchOutputRepositoryColumnAnswerType = z.infer<typeof ResearchOutputRepositoryAnswerSchema>;
+export type ResearchOutputMetadataStandardColumnAnswerType = z.infer<typeof ResearchOutputMetadataStandardAnswerSchema>;
+export type ResearchOutputLicenseColumnAnswerType = z.infer<typeof ResearchOutputLicenseAnswerSchema>;
+export type ResearchOutputCustomTableColumnAnswerType = z.infer<typeof ResearchOutputCustomTableAnswerSchema>;
 
 export type AnyTableColumnAnswerType = z.infer<typeof AnyTableColumnAnswerSchema>;
 export type AnyResearchOutputTableColumnAnswerType = z.infer<typeof AnyResearchOutputTableColumnAnswerSchema>;

--- a/src/questions/__tests__/defaults.spec.ts
+++ b/src/questions/__tests__/defaults.spec.ts
@@ -566,12 +566,13 @@ describe('questions return the expected defaults', () => {
         },
         {
           heading: "Custom Column",
+          commonStandardId: 'custom',
           help: "Explanation of what we expect the user to enter.",
           required: false,
           enabled: false,
           content: {
             type: "text",
-            attributes: { maxLength: 255 },
+            attributes: {},
             meta: { schemaVersion: "1.0" },
           }
         }

--- a/src/questions/__tests__/tableQuestion.spec.ts
+++ b/src/questions/__tests__/tableQuestion.spec.ts
@@ -134,6 +134,7 @@ describe("ResearchOutputTableQuestionSchema", () => {
         },
         {
           heading: "My Custom Field",
+          commonStandardId: 'custom',
           required: false,
           enabled: true,
           content: {

--- a/src/questions/index.ts
+++ b/src/questions/index.ts
@@ -1,4 +1,4 @@
-import { z } from 'zod';
+import { z, ZodObject } from 'zod';
 import { QuestionFormatsEnum } from './question';
 import {
   CurrencyQuestionSchema,
@@ -74,7 +74,35 @@ import {
   ResearchOutputTableQuestionType,
   DefaultResearchOutputTableQuestion,
   DefaultTableQuestion,
-  DefaultResearchOutputCustomColumn,
+  DefaultResearchOutputCustomColumn, ResearchOutputTableColumnsEnum,
+  DefaultResearchOutputTitleColumn, DefaultResearchOutputDescriptionColumn,
+  DefaultResearchOutputTypeColumn, DefaultResearchOutputDataFlagsColumn,
+  DefaultResearchOutputAccessLevelColumn, DefaultResearchOutputByteSizeColumn,
+  DefaultResearchOutputRepositoryColumn,
+  DefaultResearchOutputMetadataStandardColumn,
+  DefaultResearchOutputLicenseColumn, DefaultResearchOutputReleaseDateColumn,
+  ResearchOutputTitleColumnType,
+  ResearchOutputDescriptionColumnType,
+  ResearchOutputTypeColumnType,
+  ResearchOutputDataFlagsColumnType,
+  ResearchOutputAccessLevelColumnType,
+  ResearchOutputReleaseDateColumnType,
+  ResearchOutputByteSizeColumnType,
+  ResearchOutputRepositoryColumnType,
+  ResearchOutputMetadataStandardColumnType,
+  ResearchOutputLicenseColumnType,
+  ResearchOutputCustomTableColumnType,
+  ResearchOutputTitleColumnSchema,
+  ResearchOutputDescriptionColumnSchema,
+  ResearchOutputTypeColumnSchema,
+  ResearchOutputDataFlagsColumnSchema,
+  ResearchOutputAccessLevelColumnSchema,
+  ResearchOutputReleaseDateColumnSchema,
+  ResearchOutputByteSizeColumnSchema,
+  ResearchOutputRepositoryColumnSchema,
+  ResearchOutputMetadataStandardColumnSchema,
+  ResearchOutputLicenseColumnSchema,
+  ResearchOutputCustomColumnSchema
 } from './tableQuestions';
 
 // Export all the questions
@@ -207,6 +235,61 @@ export const QuestionDefaultMap: Record<z.infer<typeof QuestionFormatsEnum>, All
   textArea: DefaultTextAreaQuestion,
   url: DefaultURLQuestion,
 };
+
+export type AllDefaultResearchOutputTableColumnTypes =
+  | typeof DefaultResearchOutputTitleColumn
+  | typeof DefaultResearchOutputDescriptionColumn
+  | typeof DefaultResearchOutputTypeColumn
+  | typeof DefaultResearchOutputDataFlagsColumn
+  | typeof DefaultResearchOutputAccessLevelColumn
+  | typeof DefaultResearchOutputReleaseDateColumn
+  | typeof DefaultResearchOutputByteSizeColumn
+  | typeof DefaultResearchOutputRepositoryColumn
+  | typeof DefaultResearchOutputMetadataStandardColumn
+  | typeof DefaultResearchOutputLicenseColumn
+  | typeof DefaultResearchOutputCustomColumn;
+
+export interface ResearchOutputTableColumnTypeMap {
+  title: ResearchOutputTitleColumnType;
+  description: ResearchOutputDescriptionColumnType;
+  type: ResearchOutputTypeColumnType;
+  data_flags: ResearchOutputDataFlagsColumnType;
+  data_access: ResearchOutputAccessLevelColumnType;
+  issued: ResearchOutputReleaseDateColumnType;
+  byte_size: ResearchOutputByteSizeColumnType;
+  host: ResearchOutputRepositoryColumnType;
+  metadata: ResearchOutputMetadataStandardColumnType;
+  license_ref: ResearchOutputLicenseColumnType;
+  custom: ResearchOutputCustomTableColumnType;
+}
+
+export const ResearchOutputTableColumnSchemaMap: Record<string, ZodObject> = {
+  title: ResearchOutputTitleColumnSchema,
+  description: ResearchOutputDescriptionColumnSchema,
+  type: ResearchOutputTypeColumnSchema,
+  data_flags: ResearchOutputDataFlagsColumnSchema,
+  data_access: ResearchOutputAccessLevelColumnSchema,
+  issued: ResearchOutputReleaseDateColumnSchema,
+  byte_size: ResearchOutputByteSizeColumnSchema,
+  host: ResearchOutputRepositoryColumnSchema,
+  metadata: ResearchOutputMetadataStandardColumnSchema,
+  license_ref: ResearchOutputLicenseColumnSchema,
+  custom: ResearchOutputCustomColumnSchema,
+}
+
+export const DefaultResearchOutputTableColumnMap: Record<z.infer<typeof ResearchOutputTableColumnsEnum>, AllDefaultResearchOutputTableColumnTypes> = {
+  title: DefaultResearchOutputTitleColumn,
+  description: DefaultResearchOutputDescriptionColumn,
+  type: DefaultResearchOutputTypeColumn,
+  data_flags: DefaultResearchOutputDataFlagsColumn,
+  data_access: DefaultResearchOutputAccessLevelColumn,
+  issued: DefaultResearchOutputReleaseDateColumn,
+  byte_size: DefaultResearchOutputByteSizeColumn,
+  host: DefaultResearchOutputRepositoryColumn,
+  metadata: DefaultResearchOutputMetadataStandardColumn,
+  license_ref: DefaultResearchOutputLicenseColumn,
+  custom: DefaultResearchOutputCustomColumn
+}
 
 // This will ensure that object validations are against the Zod schemas defined above
 export type AnyQuestionType = z.infer<typeof AnyQuestionSchema>;

--- a/src/questions/tableQuestions.ts
+++ b/src/questions/tableQuestions.ts
@@ -103,15 +103,30 @@ export const DefaultTableQuestion = TableQuestionSchema.parse({
   columns: [DefaultTableColumn]
 });
 
+// The available columns for the research output table question type (using the commonStandardId)
+export const ResearchOutputTableColumnsEnum = z.enum([
+  'title',
+  'description',
+  'type',
+  'data_flags',
+  'data_access',
+  'issued',
+  'byte_size',
+  'host',
+  'metadata',
+  'license_ref',
+  'custom'
+]);
+
 const ResearchOutputTableColumnPreferenceSchema = z.object({
   label: z.string().default(''),    // The label of the preference option
   value: z.string().default('')     // The value of the preference option
 });
 
-const ResearchOutputTitleColumnSchema = z.object({
+export const ResearchOutputTitleColumnSchema = z.object({
   ...TableColumnSchema.shape,
   heading: z.string().default('Title'),
-  commonStandardId: z.string().optional(),
+  commonStandardId: z.literal('title'),
   help: z.string().default('Enter the title of this research output'),
   required: z.boolean().default(true),
   content: TextQuestionSchema
@@ -122,7 +137,7 @@ const DefaultResearchOutputTitleContent = {
   label: '',
   help: '',
 }
-const DefaultResearchOutputTitleColumn = ResearchOutputTitleColumnSchema.parse({
+export const DefaultResearchOutputTitleColumn = ResearchOutputTitleColumnSchema.parse({
   // This commonStandardId is tied to how we render the dataset in the RDA Common Standard.
   // Any change will also need to be made to `buildDataset` function of
   // `src/lambda/layer/dmp.ts` in the `dmptool-infrastructure` repo.`
@@ -132,10 +147,10 @@ const DefaultResearchOutputTitleColumn = ResearchOutputTitleColumnSchema.parse({
   content: DefaultResearchOutputTitleContent
 });
 
-const ResearchOutputDescriptionColumnSchema = z.object({
+export const ResearchOutputDescriptionColumnSchema = z.object({
   ...TableColumnSchema.shape,
   heading: z.string().default('Description'),
-  commonStandardId: z.string().optional(),
+  commonStandardId: z.literal('description'),
   help: z.string().default('Enter a brief description of this research output'),
   content: TextAreaQuestionSchema
 });
@@ -145,7 +160,7 @@ const DefaultResearchOutputDescriptionContent = {
   label: '',
   help: '',
 }
-const DefaultResearchOutputDescriptionColumn = ResearchOutputDescriptionColumnSchema.parse({
+export const DefaultResearchOutputDescriptionColumn = ResearchOutputDescriptionColumnSchema.parse({
   // This commonStandardId is tied to how we render the dataset in the RDA Common Standard.
   // Any change will also need to be made to `buildDataset` function of
   // `src/lambda/layer/dmp.ts` in the `dmptool-infrastructure` repo.`
@@ -155,7 +170,7 @@ const DefaultResearchOutputDescriptionColumn = ResearchOutputDescriptionColumnSc
   content: DefaultResearchOutputDescriptionContent
 });
 
-const DefaultResearchOutputTypeOptions = [
+export const DefaultResearchOutputTypeOptions = [
   { label: 'Dataset', value: 'dataset' },
   { label: 'Software', value: 'software' },
   { label: 'Other', value: 'other' },
@@ -166,15 +181,15 @@ const DefaultResearchOutputTypeContent = SelectBoxQuestionSchema.parse({
   meta: DefaultMeta,
   options: DefaultResearchOutputTypeOptions
 });
-const ResearchOutputTypeColumnSchema = z.object({
+export const ResearchOutputTypeColumnSchema = z.object({
   ...TableColumnSchema.shape,
   heading: z.string().default('Type'),
-  commonStandardId: z.string().optional(),
+  commonStandardId: z.literal('type'),
   help: z.string().default('Select the type of this research output'),
   required: z.boolean().default(true),
   content: SelectBoxQuestionSchema,
 });
-const DefaultResearchOutputTypeColumn = ResearchOutputTypeColumnSchema.parse({
+export const DefaultResearchOutputTypeColumn = ResearchOutputTypeColumnSchema.parse({
   // This commonStandardId is tied to how we render the dataset in the RDA Common Standard.
   // Any change will also need to be made to `buildDataset` function of
   // `src/lambda/layer/dmp.ts` in the `dmptool-infrastructure` repo.`
@@ -184,7 +199,7 @@ const DefaultResearchOutputTypeColumn = ResearchOutputTypeColumnSchema.parse({
   content: DefaultResearchOutputTypeContent,
 });
 
-const DefaultResearchOutputDataFlagsOptions = [
+export const DefaultResearchOutputDataFlagsOptions = [
   { label: 'May contain sensitive data?', value: 'sensitive', checked: false },
   { label: 'May contain personally identifiable information?', value: 'personal', checked: false },
 ];
@@ -194,15 +209,15 @@ const DefaultResearchOutputDataFlagsContent = CheckboxesQuestionSchema.parse({
   meta: DefaultMeta,
   options: DefaultResearchOutputDataFlagsOptions
 });
-const ResearchOutputDataFlagsColumnSchema = z.object({
+export const ResearchOutputDataFlagsColumnSchema = z.object({
   ...TableColumnSchema.shape,
   heading: z.string().default('Data Flags'),
-  commonStandardId: z.string().optional(),
+  commonStandardId: z.literal('data_flags'),
   help: z.string().default('Mark all of the statements that are true about the dataset'),
   enabled: z.boolean().default(false),
   content: CheckboxesQuestionSchema,
 })
-const DefaultResearchOutputDataFlagsColumn = ResearchOutputDataFlagsColumnSchema.parse({
+export const DefaultResearchOutputDataFlagsColumn = ResearchOutputDataFlagsColumnSchema.parse({
   // This commonStandardId is tied to how we render the dataset in the RDA Common Standard.
   // Any change will also need to be made to `buildDataset` function of
   // `src/lambda/layer/dmp.ts` in the `dmptool-infrastructure` repo.`
@@ -212,7 +227,7 @@ const DefaultResearchOutputDataFlagsColumn = ResearchOutputDataFlagsColumnSchema
   content: DefaultResearchOutputDataFlagsContent
 });
 
-const DefaultResearchOutputAccessLevelOptions = [
+export const DefaultResearchOutputAccessLevelOptions = [
   { label: 'Open Access', value: 'open' },
   { label: 'Restricted Access', value: 'restricted' },
   { label: 'Other', value: 'closed' },
@@ -223,10 +238,10 @@ const DefaultResearchOutputAccessLevelContent = RadioButtonsQuestionSchema.parse
   meta: DefaultMeta,
   options: DefaultResearchOutputAccessLevelOptions
 });
-const ResearchOutputAccessLevelColumnSchema = z.object({
+export const ResearchOutputAccessLevelColumnSchema = z.object({
   ...TableColumnSchema.shape,
   heading: z.string().default('Access Level'),
-  commonStandardId: z.string().optional(),
+  commonStandardId: z.literal('data_access'),
   help: z.string().default('Select the access level for this research output'),
   enabled: z.boolean().default(false),
   content: RadioButtonsQuestionSchema,
@@ -241,15 +256,15 @@ export const DefaultResearchOutputAccessLevelColumn = ResearchOutputAccessLevelC
   content: DefaultResearchOutputAccessLevelContent
 });
 
-const ResearchOutputReleaseDateColumnSchema = z.object({
+export const ResearchOutputReleaseDateColumnSchema = z.object({
   ...TableColumnSchema.shape,
   heading: z.string().default('Anticipated Release Date'),
-  commonStandardId: z.string().optional(),
+  commonStandardId: z.literal('issued'),
   help: z.string().default('The anticipated release date for the research output'),
   enabled: z.boolean().default(false),
   content: DateQuestionSchema,
 })
-const DefaultResearchOutputReleaseDateColumn = ResearchOutputReleaseDateColumnSchema.parse({
+export const DefaultResearchOutputReleaseDateColumn = ResearchOutputReleaseDateColumnSchema.parse({
   // This commonStandardId is tied to how we render the dataset in the RDA Common Standard.
   // Any change will also need to be made to `buildDataset` function of
   // `src/lambda/layer/dmp.ts` in the `dmptool-infrastructure` repo.`
@@ -259,7 +274,7 @@ const DefaultResearchOutputReleaseDateColumn = ResearchOutputReleaseDateColumnSc
   content: DefaultDateQuestion,
 });
 
-const DefaultResearchOutputByteSizeOptions = [
+export const DefaultResearchOutputByteSizeOptions = [
   { label: 'bytes', value: 'bytes' },
   { label: 'KB (kilobytes)', value: 'kb' },
   { label: 'MB (megabytes)', value: 'mb' },
@@ -276,15 +291,15 @@ const DefaultResearchOutputByteSizeContent = NumberWithContextQuestionSchema.par
   attributes: DefaultResearchOutputByteSizeContentAttributes,
   meta: DefaultMeta,
 });
-const ResearchOutputByteSizeColumnSchema = z.object({
+export const ResearchOutputByteSizeColumnSchema = z.object({
   ...TableColumnSchema.shape,
   heading: z.string().default('Byte Size'),
-  commonStandardId: z.string().optional(),
+  commonStandardId: z.literal('byte_size'),
   help: z.string().default('The size of the research output in bytes'),
   enabled: z.boolean().default(false),
   content: NumberWithContextQuestionSchema,
 });
-const DefaultResearchOutputByteSizeColumn = ResearchOutputByteSizeColumnSchema.parse({
+export const DefaultResearchOutputByteSizeColumn = ResearchOutputByteSizeColumnSchema.parse({
   // This commonStandardId is tied to how we render the dataset in the RDA Common Standard.
   // Any change will also need to be made to `buildDataset` function of
   // `src/lambda/layer/dmp.ts` in the `dmptool-infrastructure` repo.`
@@ -294,16 +309,16 @@ const DefaultResearchOutputByteSizeColumn = ResearchOutputByteSizeColumnSchema.p
   content: DefaultResearchOutputByteSizeContent
 });
 
-const ResearchOutputRepositoryColumnSchema = z.object({
+export const ResearchOutputRepositoryColumnSchema = z.object({
   ...TableColumnSchema.shape,
   heading: z.string().default('Repository'),
-  commonStandardId: z.string().optional(),
+  commonStandardId: z.literal('host'),
   help: z.string().default('Select repository(ies) you would prefer users to deposit in'),
   enabled: z.boolean().default(false),
   content: RepositorySearchQuestionSchema,
   preferences: z.array(ResearchOutputTableColumnPreferenceSchema).default([])
 });
-const DefaultResearchOutputRepositoryColumn = ResearchOutputRepositoryColumnSchema.parse({
+export const DefaultResearchOutputRepositoryColumn = ResearchOutputRepositoryColumnSchema.parse({
   heading: 'Repository(ies)',
   commonStandardId: 'host',
   enabled: false,
@@ -311,16 +326,16 @@ const DefaultResearchOutputRepositoryColumn = ResearchOutputRepositoryColumnSche
   preferences: []
 });
 
-const ResearchOutputMetadataStandardColumnSchema = z.object({
+export const ResearchOutputMetadataStandardColumnSchema = z.object({
   ...TableColumnSchema.shape,
   heading: z.string().default('Metadata Standard'),
-  commonStandardId: z.string().optional(),
+  commonStandardId: z.literal('metadata'),
   help: z.string().default('Select metadata standard(s) you would prefer users to use'),
   enabled: z.boolean().default(false),
   content: MetadataStandardSearchQuestionSchema,
   preferences: z.array(ResearchOutputTableColumnPreferenceSchema).default([])
 });
-const DefaultResearchOutputMetadataStandardColumn = ResearchOutputMetadataStandardColumnSchema.parse({
+export const DefaultResearchOutputMetadataStandardColumn = ResearchOutputMetadataStandardColumnSchema.parse({
   // This commonStandardId is tied to how we render the dataset in the RDA Common Standard.
   // Any change will also need to be made to `buildDataset` function of
   // `src/lambda/layer/dmp.ts` in the `dmptool-infrastructure` repo.`
@@ -331,16 +346,16 @@ const DefaultResearchOutputMetadataStandardColumn = ResearchOutputMetadataStanda
   preferences: []
 });
 
-const ResearchOutputLicenseColumnSchema = z.object({
+export const ResearchOutputLicenseColumnSchema = z.object({
   ...TableColumnSchema.shape,
   heading: z.string().default('License'),
-  commonStandardId: z.string().optional(),
+  commonStandardId: z.literal('license_ref'),
   help: z.string().default('Select the license you will apply to the research output'),
   enabled: z.boolean().default(false),
   content: LicenseSearchQuestionSchema,
   preferences: z.array(ResearchOutputTableColumnPreferenceSchema).default([])
 });
-const DefaultResearchOutputLicenseColumn = ResearchOutputLicenseColumnSchema.parse({
+export const DefaultResearchOutputLicenseColumn = ResearchOutputLicenseColumnSchema.parse({
   // This commonStandardId is tied to how we render the dataset in the RDA Common Standard.
   // Any change will also need to be made to `buildDataset` function of
   // `src/lambda/layer/dmp.ts` in the `dmptool-infrastructure` repo.`
@@ -372,18 +387,20 @@ const DefaultResearchOutputCustomContent = ResearchOutputCustomContentSchema.par
 export const ResearchOutputCustomColumnSchema = z.object({
   ...TableColumnSchema.shape,
   heading: z.string().default('Custom Column'),
+  commonStandardId: z.literal('custom'),
   help: z.string().default('Explanation of what we expect the user to enter.'),
   enabled: z.boolean().default(false),
   content: ResearchOutputCustomContentSchema,
 });
 export const DefaultResearchOutputCustomColumn = ResearchOutputCustomColumnSchema.parse({
   heading: 'Custom Column',
+  commonStandardId: 'custom',
   enabled: false,
   content: DefaultResearchOutputCustomContent
 });
 
 // Add this BEFORE ResearchOutputTableQuestionSchema
-const AnyResearchOutputColumnSchema = z.union([
+export const AnyResearchOutputColumnSchema = z.union([
   ResearchOutputTitleColumnSchema,
   ResearchOutputDescriptionColumnSchema,
   ResearchOutputTypeColumnSchema,
@@ -425,6 +442,16 @@ export const DefaultResearchOutputTableQuestion = ResearchOutputTableQuestionSch
 // This will ensure that object validations are against the Zod schemas defined above
 export type TableQuestionType = z.infer<typeof TableQuestionSchema>;
 export type AnyTableColumnQuestionType = z.infer<typeof AnyTableColumnQuestionSchema>;
+export type ResearchOutputTitleColumnType = z.infer<typeof ResearchOutputTitleColumnSchema>;
+export type ResearchOutputDescriptionColumnType = z.infer<typeof ResearchOutputDescriptionColumnSchema>;
+export type ResearchOutputTypeColumnType = z.infer<typeof ResearchOutputTypeColumnSchema>;
+export type ResearchOutputDataFlagsColumnType = z.infer<typeof ResearchOutputDataFlagsColumnSchema>;
+export type ResearchOutputAccessLevelColumnType = z.infer<typeof ResearchOutputAccessLevelColumnSchema>;
+export type ResearchOutputReleaseDateColumnType = z.infer<typeof ResearchOutputReleaseDateColumnSchema>;
+export type ResearchOutputByteSizeColumnType = z.infer<typeof ResearchOutputByteSizeColumnSchema>;
+export type ResearchOutputRepositoryColumnType = z.infer<typeof ResearchOutputRepositoryColumnSchema>;
+export type ResearchOutputMetadataStandardColumnType = z.infer<typeof ResearchOutputMetadataStandardColumnSchema>;
+export type ResearchOutputLicenseColumnType = z.infer<typeof ResearchOutputLicenseColumnSchema>;
 export type ResearchOutputCustomTableColumnType = z.infer<typeof ResearchOutputCustomColumnSchema>;
 export type AnyResearchOutputColumnType = z.infer<typeof AnyResearchOutputColumnSchema>;
 export type ResearchOutputTableQuestionType = z.infer<typeof ResearchOutputTableQuestionSchema>;


### PR DESCRIPTION
## Description

Fixes [#284](https://github.com/CDLUC3/dmptool-doc/issues/284)

**See corresponding PRs in narrative generator, apollo server, and the @dmptool/utils repos**

- Refactored the ResearchOutputTable Question and Answer types so that the `commonStandardId` for every column is not a `literal` instead of an `optional` string
- Added export for all the `commonStandardId` values as `ResearchOutputTableColumnsEnum`
- Added new exported types
  - `AllDefaultResearchOutputTableColumnAnswerTypes`
  - `AllDefaultResearchOutputTableColumnTypes`
- Added new exports to assist with mapping `commonStandardId`
  - `ResearchOutputTableColumnAnswerTypeMap`
  - `ResearchOutputTableColumnAnswerMap`
  - `DefaultResearchOutputTableColumnAnswerMap`
  - `ResearchOutputTableColumnSchemaMap`
  - `DefaultResearchOutputTableColumnSchemaMap`
- Updated `eslint` version
- Added overrides for `@babel/core` and `js-yaml`

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## How Has This Been Tested?

All tests are passing and verified that the narrative generator, Apollo server and UI are all still working after upgrading and to this version (and updating their codebases)

## Checklist:
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I updated the CHANGELOG.md and added documentation if necessary
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
